### PR TITLE
🐛 #29 ログイン時にuserのプロフィール情報を読み込むよう修正しました

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,15 @@ import { useAppDispatch, useAppSelector } from "./app/hooks";
 import { selectUser, login, logout } from "./features/userSlice";
 import Feed from "./components/Feed/Feed";
 import UserAuthentication from "./components/UserAuthentication/UserAuthentication";
-import { auth } from "./firebase";
+import { auth, db } from "./firebase";
 import { onAuthStateChanged, Unsubscribe, User } from "firebase/auth";
+import {
+  doc,
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  getDoc,
+} from "firebase/firestore";
 
 const App: React.FC = () => {
   const user = useAppSelector(selectUser);
@@ -15,16 +22,39 @@ const App: React.FC = () => {
       auth,
       async (authUser: User | null) => {
         if (authUser) {
-          dispatch(login(authUser.uid));
+          let userType: "enterpriseUser" | "normalUser" | null = null;
+          const userRef: DocumentReference<DocumentData> = doc(
+            db,
+            "users",
+            authUser.uid
+          );
+          const userSnap: DocumentSnapshot<DocumentData> = await getDoc(
+            userRef
+          );
+          if (userSnap.exists()) {
+            userType = userSnap.data().userType;
+          } else {
+            console.log("対象のドキュメントは見つかりませんでした。");
+          }
+
+          dispatch(
+            login({
+              uid: authUser.uid,
+              displayName: authUser.displayName,
+              photoURL: authUser.photoURL,
+              userType: userType,
+            })
+          );
         } else {
           dispatch(logout());
         }
       }
     );
+
     return () => {
       unsubscribe();
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
   return <>{user.uid ? <Feed /> : <UserAuthentication />}</>;
 };

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -4,8 +4,8 @@ import { updateUserProfile } from "../../features/userSlice";
 import { auth, db, storage } from "../../firebase";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { doc, setDoc } from "firebase/firestore";
-import { Visibility, VisibilityOff, AddAPhoto } from "@material-ui/icons";
 import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { Visibility, VisibilityOff, AddAPhoto } from "@material-ui/icons";
 
 const SignUp = (props: {
   backToLogin: React.MouseEventHandler<HTMLButtonElement> | undefined;

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -8,24 +8,27 @@ export interface UserProfile {
 
 export interface User {
   uid: string;
-  displayName: string;
+  displayName: string | null;
   userType: "enterpriseUser" | "normalUser" | null;
-  photoURL: string;
+  photoURL: string | null;
 }
 
 const initialState: User = {
   uid: "",
   displayName: "",
-  userType: null,
   photoURL: "",
+  userType: null,
 };
 
 export const userSlice = createSlice({
   name: "user",
   initialState: initialState,
   reducers: {
-    login: (state, action: PayloadAction<User["uid"]>) => {
-      state.uid = action.payload;
+    login: (state, action: PayloadAction<User>) => {
+      state.uid = action.payload.uid;
+      state.displayName = action.payload.displayName;
+      state.photoURL = action.payload.photoURL;
+      state.userType = action.payload.userType;
     },
     logout: (state) => {
       state.uid = "";
@@ -36,7 +39,7 @@ export const userSlice = createSlice({
     },
     updateUserType: (
       state,
-      action: PayloadAction<"enterpriseUser"|"normalUser"|null>
+      action: PayloadAction<"enterpriseUser" | "normalUser" | null>
     ) => {
       state.userType = action.payload;
     },
@@ -45,7 +48,8 @@ export const userSlice = createSlice({
 
 // NOTE >> 各コンポーネントで使用できるようにuserSliceのアクションを
 //         エクスポートします。
-export const { login, logout, updateUserProfile, updateUserType } = userSlice.actions;
+export const { login, logout, updateUserProfile, updateUserType } =
+  userSlice.actions;
 // NOTE >> ストアで取り込むため、userSliceのリデューサーをエクスポートします。
 export default userSlice.reducer;
 export const selectUser = (state: RootState) => state.user;


### PR DESCRIPTION
お疲れ様です✨
userのプロフィールのうち、displayNameとphotoURLはAuthから、userTypeはFirestoreから取得するようにしました。
また、userSliceのloginアクションで取得する情報につきまして、`uid`1つだけだったものに、`displayName`、`photoURL`、`userType`の３つを追加しました。
ご確認のほどよろしくお願いします🙇‍♂️