### PR TITLE
♻️ userSliceのプロパティuserTypeの値をbusinessUserに変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => {
       auth,
       async (authUser: User | null) => {
         if (authUser) {
-          let userType: "enterpriseUser" | "normalUser" | null = null;
+          let userType: "businessUser" | "normalUser" | null = null;
           const userRef: DocumentReference<DocumentData> = doc(
             db,
             "users",

--- a/src/components/SelectUserType/SelectUserType.tsx
+++ b/src/components/SelectUserType/SelectUserType.tsx
@@ -7,7 +7,7 @@ import { doc, updateDoc } from "firebase/firestore";
 
 const SelectUserType = () => {
   const [userType, setUserType] = useState<
-    "enterpriseUser" | "normalUser" | null
+    "businessUser" | "normalUser" | null
   >(null);
 
   const dispatch = useAppDispatch();
@@ -15,7 +15,7 @@ const SelectUserType = () => {
 
   const registUserType: (
     e: React.MouseEvent<HTMLInputElement, MouseEvent>,
-    userType: "enterpriseUser" | "normalUser" | null
+    userType: "businessUser" | "normalUser" | null
   ) => Promise<void> = async (e, userType) => {
     e.preventDefault();
     const userRef = doc(db, "users", user.uid);
@@ -29,7 +29,7 @@ const SelectUserType = () => {
       <p>ユーザータイプを選択してください。</p>
       <form>
         <div>
-          <label htmlFor="enterpriseUser">
+          <label htmlFor="businessUser">
             <p>企業ユーザー</p>
             <p>働き手を探している企業や事業者向け</p>
             <p>
@@ -38,12 +38,12 @@ const SelectUserType = () => {
           </label>
           <input
             type="radio"
-            value="enterpriseUser"
+            value="businessUser"
             name="userType"
-            id="enterpriseUser"
-            data-testid="enterpriseUser"
+            id="businessUser"
+            data-testid="businessUser"
             onChange={() => {
-              setUserType("enterpriseUser");
+              setUserType("businessUser");
             }}
           />
         </div>

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -9,7 +9,7 @@ export interface UserProfile {
 export interface User {
   uid: string;
   displayName: string | null;
-  userType: "enterpriseUser" | "normalUser" | null;
+  userType: "businessUser" | "normalUser" | null;
   photoURL: string | null;
 }
 
@@ -39,7 +39,7 @@ export const userSlice = createSlice({
     },
     updateUserType: (
       state,
-      action: PayloadAction<"enterpriseUser" | "normalUser" | null>
+      action: PayloadAction<"businessUser" | "normalUser" | null>
     ) => {
       state.userType = action.payload;
     },


### PR DESCRIPTION
## Issue
 #52 

## 内容
- [x] userSlice.tsの型定義を変更
- [x] userTypeを参照しているコンポーネント(SelectUserType.tsx、App.tsx）の内容を修正

## 確認手順

1.**新規登録**をクリック

<img width="1434" alt="スクリーンショット 2022-03-07 18 33 53" src="https://user-images.githubusercontent.com/98272835/157005522-b2f17042-3cd8-4484-8a08-9083bb25553b.png">

2.**会社名・個人名**、**メールアドレス**、**パスワード**を入力　→　**登録する**をクリック

<img width="1403" alt="スクリーンショット 2022-03-07 18 45 58" src="https://user-images.githubusercontent.com/98272835/157007490-8979de26-6692-4e2f-b96d-49d439e137bb.png">

3.ユーザータイプ選択画面を表示

<img width="1406" alt="スクリーンショット 2022-03-07 18 49 11" src="https://user-images.githubusercontent.com/98272835/157007696-a901b5db-0839-4e7d-8f20-d4e1575496c7.png">

### 期待される結果

- [ ] アカウントを作成した際、SelectUserTypeコンポーネントにてuserTypeを選択できる
- [ ] SelectUserTypeコンポーネントで「企業ユーザー」を選択した際、ステートの値がbusinessUserとなっている

<img width="1440" alt="スクリーンショット 2022-03-07 18 51 04" src="https://user-images.githubusercontent.com/98272835/157008003-75234f1a-87c3-4133-87e5-b5fdab7c8823.png">

- [ ] Firestoreのusersコレクションに登録される新規ユーザーのuserTypeがbusinessUserとなっている

<img width="1421" alt="スクリーンショット 2022-03-07 18 52 58" src="https://user-images.githubusercontent.com/98272835/157008770-a07fba53-18ad-46bd-856a-aa1cab852ac4.png">


