### PR TITLE
:sparkles: Firestoreのテキスト情報を表示する機能の実装

### DIFF
--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { selectUser, updateUserProfile } from "../../features/userSlice";
 import { auth, db, storage } from "../../firebase";
@@ -6,6 +6,7 @@ import {
   doc,
   DocumentData,
   DocumentReference,
+  getDoc,
   setDoc,
 } from "firebase/firestore";
 import {
@@ -41,6 +42,12 @@ const EditProfileForEnterprise = () => {
     "users",
     `${user.uid}`
   );
+  const getUser = async () => {
+    const userSnap = await getDoc(userRef);
+    if (userSnap) {
+      setDisplayName(userSnap.data()!.displayName);
+    }
+  };
   const enterpriseRef: DocumentReference<DocumentData> = doc(
     db,
     "users",
@@ -48,6 +55,22 @@ const EditProfileForEnterprise = () => {
     "enterprise",
     `${user.uid}`
   );
+  const getEnterprise = async () => {
+    const enterpriseSnap = await getDoc(enterpriseRef);
+    if (enterpriseSnap) {
+      setIntroduction(enterpriseSnap.data()!.introduction);
+      setOwner(enterpriseSnap.data()!.owner);
+      setTypeOfWork(enterpriseSnap.data()!.typeOfWork);
+      setAddress(enterpriseSnap.data()!.address);
+    }
+  };
+
+  useEffect(() => {
+    console.log("useEffect is done!");
+    getUser();
+    getEnterprise();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onChangeImageHandler: (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -100,7 +123,7 @@ const EditProfileForEnterprise = () => {
     setBackgroundChange(false);
   };
 
-  const editProfile = async (e:React.FormEvent<HTMLFormElement>) => {
+  const editProfile = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log("submit is called.");
     await setDoc(
@@ -123,7 +146,7 @@ const EditProfileForEnterprise = () => {
     );
     await updateProfile(auth.currentUser!, {
       displayName: displayName,
-    }).then(()=>{
+    }).then(() => {
       console.log(auth.currentUser!);
     });
     dispatch(

--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -66,7 +66,9 @@ const EditProfileForEnterprise = () => {
   };
 
   useEffect(() => {
-    console.log("useEffect is done!");
+    if (process.env.NODE_ENV === 'development') {
+      console.log('useEffectが実行されました');
+    }
     getUser();
     getEnterprise();
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Issue
#63 

## 変更内容
- [x] editProfileForEnterpriseに新しく`useEffect`のモジュールをインポート
- [x] FirestoreからgetDocのモジュールを追加
- [x] Firestoreのusers/user.uidドキュメントからテキスト情報を取得する関数`getUser()`を追加
- [x] Firestoreのusers/user.uid/enterprise/user.uidドキュメントからテキスト情報を取得する関数`getEnterprise()`を追加
- [x] useEffectでFirestoreからテキスト情報を読み込む処理を追加

## ✅確認手順

### 1.レンダリング時に、入力フォームとステートにFirestoreのテキスト情報が読み込まれているか

tsugumonにログイン　メールアドレス:testuser@gmail.com　　パスワード:testuser

- [x] 入力フォームにFirestoreのテキスト情報が読み込まれているか確認
<img width="921" alt="スクリーンショット 2022-03-14 21 57 45" src="https://user-images.githubusercontent.com/98272835/158176843-008acca5-d1e6-4794-a25d-deccb23859bf.png">


- [x] editProfileForEnterpriseのステートにFirestoreのテキスト情報が読み込まれているか確認
<img width="1439" alt="スクリーンショット 2022-03-14 22 01 00" src="https://user-images.githubusercontent.com/98272835/158177408-c168bace-e7a4-492e-a358-096eb6ad017d.png">



### 2.`useEffect()`の中の`console.log("useEffect is done!");`が一度だけ呼ばれるか

- [x] DevToolsでレンダリング時に`useEffect()`の中の`console.log("useEffect is done!");`が一度だけ呼ばれるか確認
<img width="1440" alt="スクリーンショット 2022-03-14 22 07 16" src="https://user-images.githubusercontent.com/98272835/158178136-66b96241-6741-44ab-87f6-b5e8596224ad.png">

- [x] inputフォームにテキストを入力する際、`console.log("useEffect is done!");`が呼ばれていないか確認
<img width="1438" alt="スクリーンショット 2022-03-14 22 10 27" src="https://user-images.githubusercontent.com/98272835/158178856-3c887368-a21b-428f-99e0-6e4d6ecb9b8d.png">