### PR TITLE
Displaying stored image#65

### DIFF
--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -68,7 +68,9 @@ const EditProfileForEnterprise = () => {
   };
 
   useEffect(() => {
-    console.log("useEffect is done!");
+    if (process.env.NODE_ENV === 'development') {
+      console.log('useEffectが実行されました');
+    }
     getUser();
     getEnterprise();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -46,6 +46,7 @@ const EditProfileForEnterprise = () => {
     const userSnap = await getDoc(userRef);
     if (userSnap) {
       setDisplayName(userSnap.data()!.displayName);
+      setAvatarURL(userSnap.data()!.photoURL);
     }
   };
   const enterpriseRef: DocumentReference<DocumentData> = doc(
@@ -59,6 +60,7 @@ const EditProfileForEnterprise = () => {
     const enterpriseSnap = await getDoc(enterpriseRef);
     if (enterpriseSnap) {
       setIntroduction(enterpriseSnap.data()!.introduction);
+      setBackgroundURL(enterpriseSnap.data()!.backgroundURL);
       setOwner(enterpriseSnap.data()!.owner);
       setTypeOfWork(enterpriseSnap.data()!.typeOfWork);
       setAddress(enterpriseSnap.data()!.address);


### PR DESCRIPTION
## Issue
#65 

## 変更内容
- [x] 関数`getUser()`に、アバター画像のダウンロードURLを取得するコードを追記。
useEffect()でdisplayNameだけでなく、アバター画像も取得・表示するよう変更。
- [x] 関数`getEnterprise()`に、背景画像のダウンロードURLを取得するコードを追記。

## ✅  確認手順

### 1.レンダリング時に、アバター画像と背景画像のDownloadURLが読みこまれているか
trugumonにログイン　メールアドレス：testuser@gmail.com　　パスワード：testuser

- [x] アバター画像と背景画像が表示されるか確認
<img width="1440" alt="スクリーンショット 2022-03-14 23 00 44" src="https://user-images.githubusercontent.com/98272835/158188401-da5a5175-fcfd-4876-b39d-1eadfeeac257.png">

- [x] editProfileForEnterpriseのステートにDownloadURLが読み込まれているか確認
<img width="1406" alt="スクリーンショット 2022-03-14 23 05 51" src="https://user-images.githubusercontent.com/98272835/158188916-373ef8b1-f841-43e4-a7c2-ac8506575d72.png">


### 2.アバター画像が登録されていない際、NoUserアイコンが表示されるか

- [x] アバター画像が登録されていない際、NoUserアイコンが表示されるか確認
*Storage*
<img width="1440" alt="スクリーンショット 2022-03-14 22 51 53" src="https://user-images.githubusercontent.com/98272835/158190593-bd39f48d-687c-4189-8990-0a3dedc7872b.png">

*Firestore*
<img width="1440" alt="スクリーンショット 2022-03-14 22 55 01" src="https://user-images.githubusercontent.com/98272835/158190218-90b6e1d6-f0b3-4492-ad45-1fcb72ea8412.png">

*表示内容*
<img width="1440" alt="スクリーンショット 2022-03-14 22 54 28" src="https://user-images.githubusercontent.com/98272835/158191202-35bfa5f0-5e99-41e4-9316-55cb4bf41cc3.png">

### 3. アバター画像や背景画像を変更・登録した際、問題なくFirebaseに情報が登録されるか

- [x] レンダリングされた後、画像を変更・登録した際、問題なくStorageに画像が保存されるか確認
- [x] レンダリングされた後、画像を変更・登録した際、問題なくFirestoreに画像のDownloadURLが保存されるか確認
