### PR TITLE
✨ アバター画像と背景画像を削除するボタンの実装

### DIFF
--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -81,7 +81,7 @@ const EditProfileForEnterprise = () => {
     getUser();
     getEnterprise();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [avatarURL, backgroundURL]);
 
   const onChangeImageHandler: (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -187,7 +187,7 @@ const EditProfileForEnterprise = () => {
           <img
             id="backgroundPreview"
             data-testid="backgroundPreview"
-            src={backgroundURL}
+            src={backgroundURL ? backgroundURL : ""}
             alt="ユーザーの背景画像"
           />
           <button
@@ -250,6 +250,13 @@ const EditProfileForEnterprise = () => {
           onChangeImageHandler(e, "avatar");
         }}
       />
+      <button
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          setDeleteAvatar(true);
+        }}
+      >
+        削除する
+      </button>
       {deleteAvatar && (
         <div>
           <p>現在登録されている画像を消去します。よろしいですか？</p>

--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -77,13 +77,13 @@ const EditProfileForEnterprise = () => {
   };
 
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      console.log('useEffectが実行されました');
+    if (process.env.NODE_ENV === "development") {
+      console.log("useEffectが実行されました");
     }
     getUser();
     getEnterprise();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [avatarURL, backgroundURL]);
+  }, []);
 
   const onChangeImageHandler: (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -136,7 +136,6 @@ const EditProfileForEnterprise = () => {
 
   const editProfile = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log("submit is called.");
     await setDoc(
       enterpriseRef,
       {
@@ -158,7 +157,9 @@ const EditProfileForEnterprise = () => {
     await updateProfile(auth.currentUser!, {
       displayName: displayName,
     }).then(() => {
-      console.log(auth.currentUser!);
+      if (process.env.NODE_ENV === "development") {
+        console.log(auth.currentUser!);
+      }
     });
     dispatch(
       updateUserProfile({
@@ -178,7 +179,13 @@ const EditProfileForEnterprise = () => {
     setDoc(userRef, { photoURL: "" }, { merge: true });
     setDoc(enterpriseRef, { backgroundURL: "" }, { merge: true });
     deleteObject(imageRef).then(() => {
-      console.log(`${imageFor}画像を削除しました`);
+      if (process.env.NODE_ENV === "development") {
+        console.log(`${imageFor}画像を削除しました`);
+      }
+      imageFor === "avatar" ? setAvatarURL("") : setBackgroundURL("");
+      imageFor === "avatar"
+        ? setDeleteAvatar(false)
+        : setDeleteBackground(false);
     });
   };
 
@@ -189,16 +196,19 @@ const EditProfileForEnterprise = () => {
           <img
             id="backgroundPreview"
             data-testid="backgroundPreview"
-            src={backgroundURL ? backgroundURL : ""}
+            src={backgroundURL}
             alt="ユーザーの背景画像"
           />
-          <button
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-              setDeleteBackground(true);
-            }}
-          >
-            削除する
-          </button>
+          {backgroundURL && (
+            <button
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                setDeleteBackground(true);
+              }}
+            >
+              削除する
+            </button>
+          )}
+
           {deleteBackground && (
             <div>
               <p>現在登録されている画像を消去します。よろしいですか？</p>
@@ -252,13 +262,15 @@ const EditProfileForEnterprise = () => {
           onChangeImageHandler(e, "avatar");
         }}
       />
-      <button
-        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-          setDeleteAvatar(true);
-        }}
-      >
-        削除する
-      </button>
+      {avatarURL && (
+        <button
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            setDeleteAvatar(true);
+          }}
+        >
+          削除する
+        </button>
+      )}
       {deleteAvatar && (
         <div>
           <p>現在登録されている画像を消去します。よろしいですか？</p>


### PR DESCRIPTION
## Issue
#66 

## 変更内容
- [ ] Firebase Storageから`deleteObject`のモジュールを追加インポート
- [ ] アバター画像と背景画像の参照を行う関数`avatarRef`と`backgroundRef`の追加
- [ ] `console.log("submit is called.");`の削除
- [ ] `console.log(auth.currentUser!);`を以下のとおりリファクタリング
``` typescript
      if (process.env.NODE_ENV === "development") {
        console.log(auth.currentUser!);
      }
```

- [ ] 画像が登録されているFirestoreのフィールドの初期化、Storageの画像データを削除、ステートの初期化を行う関数`deleteImage`の追加
- [ ] JSXに「削除する」ボタンの追加

## ✅  動作チェック

**検証手順** 

1.tsugumonにログイン
　メールアドレス：testuser@gmail.com　　パスワード：testuser

2.EditProfileForEnterpriseが表示される

以下の項目を検証する

## backgroundURLの削除について
- [ ] backgroundURLが登録されているとき、「削除する」ボタンが表示されているか
- [ ] 背景画像の「削除する」ボタンをクリックしたとき、「現在登録されている画像を消去します。よろしいですか？」の文章が表示されるか
- [ ] 背景画像の「削除する」ボタンをクリックしたとき、「はい」と「いいえ」のボタンは表示されるか
- [ ] 「いいえ」ボタンを押したとき、初期表示状態に戻るか（deleteBackgroundのステートが`falese`に変化するか）
- [ ] 「はい」ボタンを押したとき、backgroundURLのステートは空文字になるか
- [ ] 「はい」ボタンを押したとき、Firebase Storageから背景画像は削除されるか
- [ ] 「はい」ボタンを押したとき、Firestoreのusers/user.uid/enterprise_user.uidのドキュメントのbackgroundURLが空文字となっているか
- [ ]  「はい」ボタンを押したとき、初期表示に戻るか（deleteBackgroundのステートが`false`に変化するか）

## avatarURLの削除について
- [ ] avatarURLが登録されているとき、「削除する」ボタンが表示されているか
- [ ] アバター画像の「削除する」ボタンをクリックしたとき、「現在登録されている画像を消去します。よろしいですか？」の文章が表示されるか
- [ ] アバター画像の「削除する」ボタンをクリックしたとき、「はい」と「いいえ」のボタンは表示されるか
- [ ] 「いいえ」ボタンを押したとき、初期表示状態に戻るか（deleteAvatarのステートが`falese`に変化するか）
- [ ] 「はい」ボタンを押したとき、avatarURLのステートは空文字になるか
- [ ] 「はい」ボタンを押したとき、Firebase Storageからアバター画像は削除されるか
- [ ] 「はい」ボタンを押したとき、Firestoreのusers/user.uidのドキュメントのphotoURLが空文字となっているか
- [ ]  「はい」ボタンを押したとき、初期表示に戻るか（deleteAvatarのステートが`false`に変化するか）



