### PR TITLE
✨ ユーザーの初めてのログインを感知する機能を実装

### DIFF
--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -133,7 +133,9 @@ const EditProfileForEnterprise = () => {
     setBackgroundChange(false);
   };
 
-  const editProfile = async (e: React.FormEvent<HTMLFormElement>) => {
+  const editProfile: (
+    e: React.FormEvent<HTMLFormElement>
+  ) => Promise<void> = async (e) => {
     e.preventDefault();
     await setDoc(
       enterpriseRef,

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -1,22 +1,27 @@
-import { useAppSelector } from "../../app/hooks";
-import { selectUser } from "../../features/userSlice";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
+import { selectUser, logout, toggleIsNewUser } from "../../features/userSlice";
 import SelectUserType from "../SelectUserType/SelectUserType";
 import { auth } from "../../firebase";
 import { signOut } from "firebase/auth";
 import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
+import React from "react";
 
 const Feed = () => {
+  const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
+
   return (
     <>
       {user.userType ? (
         <div>
           <EditProfileForEnterprise />
           <button
-            onClick={() => {
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               signOut(auth).catch((error: any) => {
                 console.log(`エラーが発生しました\n${error.message}`);
               });
+              dispatch(logout());
+              dispatch(toggleIsNewUser(false));
             }}
           >
             logout

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useAppDispatch } from "../../app/hooks";
-import { updateUserProfile } from "../../features/userSlice";
+import { updateUserProfile, toggleIsNewUser } from "../../features/userSlice";
 import { auth, db, storage } from "../../firebase";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { doc, setDoc } from "firebase/firestore";
@@ -64,7 +64,6 @@ const SignUp = (props: {
       const fileName: string = randomCharactor;
       await uploadBytes(ref(storage, `avatars/${fileName}`), avatarImage);
       url = await getDownloadURL(ref(storage, `avatars/${fileName}`));
-      console.log(url);
     }
     if (authUser.user) {
       await updateProfile(authUser.user, {
@@ -86,6 +85,7 @@ const SignUp = (props: {
         photoURL: url,
       })
     );
+    dispatch(toggleIsNewUser(true));
   };
 
   return (

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -1,12 +1,18 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "../app/store";
 
+export interface User {
+  uid: string;
+  displayName: string | null;
+  userType: "enterpriseUser" | "normalUser" | null;
+  photoURL: string | null;
+  isNewUser: boolean;
+}
 export interface UserProfile {
   displayName: string;
   photoURL: string;
 }
-
-export interface User {
+export interface UserLogin {
   uid: string;
   displayName: string | null;
   userType: "enterpriseUser" | "normalUser" | null;
@@ -18,20 +24,24 @@ const initialState: User = {
   displayName: "",
   photoURL: "",
   userType: null,
+  isNewUser: false,
 };
 
 export const userSlice = createSlice({
   name: "user",
   initialState: initialState,
   reducers: {
-    login: (state, action: PayloadAction<User>) => {
+    login: (state, action: PayloadAction<UserLogin>) => {
       state.uid = action.payload.uid;
       state.displayName = action.payload.displayName;
-      state.photoURL = action.payload.photoURL;
       state.userType = action.payload.userType;
+      state.photoURL = action.payload.photoURL;
     },
     logout: (state) => {
       state.uid = "";
+      state.displayName = "";
+      state.userType = null;
+      state.photoURL = "";
     },
     updateUserProfile: (state, action: PayloadAction<UserProfile>) => {
       state.displayName = action.payload.displayName;
@@ -43,13 +53,21 @@ export const userSlice = createSlice({
     ) => {
       state.userType = action.payload;
     },
+    toggleIsNewUser: (state, action: PayloadAction<boolean>) => {
+      state.isNewUser = action.payload;
+    },
   },
 });
 
 // NOTE >> 各コンポーネントで使用できるようにuserSliceのアクションを
 //         エクスポートします。
-export const { login, logout, updateUserProfile, updateUserType } =
-  userSlice.actions;
+export const {
+  login,
+  logout,
+  updateUserProfile,
+  updateUserType,
+  toggleIsNewUser,
+} = userSlice.actions;
 // NOTE >> ストアで取り込むため、userSliceのリデューサーをエクスポートします。
 export default userSlice.reducer;
 export const selectUser = (state: RootState) => state.user;


### PR DESCRIPTION
## Issue
#67 

## 変更の内容
- [x] userSliceにログイン時に使用するインターフェースとして`UserLogin`を追加
- [x] userSliceのreducerのloginの内容を修正
- [x] userSliceのreducerのlogoutの内容を修正　→　isNewUser以外のすべてのステートの値がリセットされるようにした
- [x] userSliceのステート「isNewUser」の値を切り替えるreducerとして、`toggleIsNewUser`を新たに追加
- [x] SignUpコンポーネントに`dispatch(toggleIsNewUser(true))`を追記して、新規登録時にuserSliceのisNewUserの値が「true」に変更されるようにした
- [x] EditProfileForEnterpriseコンポーネントの`const editProfile=()=>{}`に型注釈を追記
- [x] Feedコンポーネントでインポートするモジュールに`useAppDispatch`を追加
- [x] Feedコンポーネントでインポートするモジュールに`logout`と`toggleIsNewUser`を追加
- [x] Feedコンポーネントの「logout」ボタンをクリックした際の動作に`dispatch(logout())`と`dispatch(toggleIsNewUser(false))`を追加


## 動作チェック

1.tsugumonのログイン画面で「新規登録」をクリック

2.以下の画面のとおり必要項目を入力　→　登録をクリック 
![スクリーンショット 2022-03-21 13 42 50（2）](https://user-images.githubusercontent.com/98272835/159207040-83f1f625-a6aa-485d-8b1d-ea2a0b35c099.png)

- [x] Reduxのステートに先ほど入力した内容が反映されているか確認
- [x] ReduxのisNewUserの値が「true」となっているか確認

3.「企業ユーザー」をクリック　→　「この内容で登録する」をクリック
- [x] ReduxのuserTypeの値が「enterprise」となっているか確認
- [x] Reduxのステートのその他の値が消去されてないか確認

4.EditProfileForEnterpriseの画面で「logout」をクリック
![スクリーンショット 2022-03-21 13 54 51（2）](https://user-images.githubusercontent.com/98272835/159207279-36855005-cb62-41a9-9a3f-6b8404b36e6a.png)
- [x] Reduxのステートの値が初期化されているか確認
- [x] ReduxのisNewUserの値が「false」となっているか確認

5.新規作成したユーザーアカウントでログイン
- [x] 新規作成したユーザーアカウントのプロフィールがReduxのステートに反映されているか確認
- [x] ReduxのisNewUserの値が「false」となっているか確認

