### PR TITLE
♻️ userSliceの型Userの修正#79

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
   useEffect(() => {
     const unsubscribe: Unsubscribe = onAuthStateChanged(
       auth,
-      async (authUser: User | null) => {
+      async (authUser:User | null) => {
         if (authUser) {
           let userType: "enterpriseUser" | "normalUser" | null = null;
           const userRef: DocumentReference<DocumentData> = doc(
@@ -40,8 +40,8 @@ const App: React.FC = () => {
           dispatch(
             login({
               uid: authUser.uid,
-              displayName: authUser.displayName,
-              photoURL: authUser.photoURL,
+              displayName: authUser.displayName ? authUser.displayName : "",
+              photoURL: authUser.photoURL ? authUser.photoURL : "",
               userType: userType,
             })
           );

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -3,9 +3,9 @@ import { RootState } from "../app/store";
 
 export interface User {
   uid: string;
-  displayName: string | null;
+  displayName: string;
   userType: "enterpriseUser" | "normalUser" | null;
-  photoURL: string | null;
+  photoURL: string;
   isNewUser: boolean;
 }
 export interface UserProfile {
@@ -14,9 +14,9 @@ export interface UserProfile {
 }
 export interface UserLogin {
   uid: string;
-  displayName: string | null;
+  displayName: string;
   userType: "enterpriseUser" | "normalUser" | null;
-  photoURL: string | null;
+  photoURL: string;
 }
 
 const initialState: User = {


### PR DESCRIPTION
## Issue
#79 

## 変更点
- [x]  型`User`の`displayName`と`photoURL`の定義を以下のとおり変更しました

``` typescript
interface UserLogin {
  uid: string;
  displayName: string;
  userType: "enterpriseUser" | "normalUser" | null;
  photoURL: string;
}
```
なお、displayNameとphotoURLには、いずれも初期値として空文字(`""`)を代入するようにしています。

- [x] **App.tsx**の修正を行いました。

`onAuthStateChanged()`の結果、取得される`authUser`は、*Firebase Authentication*に保管されているユーザーのオブジェクトです。
Firebase Authenticationのオブジェクトは、Firestoreと違って 、プロパティの値がnullとなることがあります。
そのため、`authUser`のプロパティ`displayName`と`photoURL`の型は、stringとnullの両方の値を代入することができるユニオン型となります。

文字列しか使うことができない*Redux Toolkit*のレデューサー`logout`において、オブジェクト`authUser`を使用するため、以下のとおり、記述内容を変更しました。

```typescript
          dispatch(
            login({
              uid: authUser.uid,
              displayName: authUser.displayName ? authUser.displayName : "",
              photoURL: authUser.photoURL ? authUser.photoURL : "",
              userType: userType,
            })
          );
```
