### PR TITLE
✨ Uploadコンポーネントで選択した画像を取り消すボタンを実装#84

### DIFF
--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useAppSelector } from "../../app/hooks";
 import { selectUser, User } from "../../features/userSlice";
 import { useBatch } from "../../hooks/useBatch";
-import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
+import { AddPhotoAlternate, Cancel } from "@mui/icons-material";
 
 const Upload: React.FC = () => {
   const user: User = useAppSelector(selectUser);
@@ -19,7 +19,6 @@ const Upload: React.FC = () => {
     postImage!,
     caption
   );
-  
 
   const onChangeImageHandler: (
     e: React.ChangeEvent<HTMLInputElement>
@@ -43,24 +42,29 @@ const Upload: React.FC = () => {
     e.target.value = "";
   };
 
+  const resetImage: (e: React.MouseEvent<HTMLButtonElement>) => void = (e) => {
+    setPostImage(null);
+    setPostPreview("");
+  };
+
   useEffect(() => {
     switch (progress) {
       case "wait":
-        if(process.env.NODE_ENV === "development"){
+        if (process.env.NODE_ENV === "development") {
           console.log(`${progress}: アップロードの待機中`);
         }
         break;
       case "run":
-        if(process.env.NODE_ENV === "development"){
+        if (process.env.NODE_ENV === "development") {
           console.log(`${progress}: アップロードの実行中`);
         }
         break;
       case "done":
-        if(process.env.NODE_ENV === "development"){
+        if (process.env.NODE_ENV === "development") {
           console.log(`${progress}: アップロード完了`);
         }
         setTimeout(() => {
-          setUpload(false);       
+          setUpload(false);
         }, 2000);
     }
   }, [progress]);
@@ -68,7 +72,9 @@ const Upload: React.FC = () => {
   return (
     <div>
       <header>
-        <button id="cancel" type="button">キャンセルする</button>
+        <button id="cancel" type="button">
+          キャンセルする
+        </button>
         <p id="title">新規登録</p>
       </header>
       <div>
@@ -91,8 +97,11 @@ const Upload: React.FC = () => {
             }
             alt="投稿画像のプレビュー"
           />
+          <button onClick={resetImage} disabled={!postImage}>
+            <Cancel />
+          </button>
           <label htmlFor="selectImage">
-            <AddPhotoAlternateIcon />
+            <AddPhotoAlternate />
           </label>
           <label htmlFor="selectImage">画像を選択する</label>
           <input
@@ -114,15 +123,20 @@ const Upload: React.FC = () => {
             }}
           />
         </div>
-        <input id="submit" type="submit" value="投稿する" disabled={!postImage} />
+        <input
+          id="submit"
+          type="submit"
+          value="投稿する"
+          disabled={!postImage}
+        />
         <button id="cancelBottom">キャンセルする</button>
       </form>
-      {progress==="run" && (
+      {progress === "run" && (
         <div id="modal">
           <p>画像をアップロード...</p>
         </div>
       )}
-      {progress==="done" && (
+      {progress === "done" && (
         <div id="toast">
           <p>アップロードが完了しました!</p>
         </div>


### PR DESCRIPTION
## Issue
#84 

## 変更した内容
** Upload.tsx **
- [x] Material UI の Icons から`Cancel`をインポート
- [x] `postImage`と`postPreview`を初期化する関数`resetImage`を宣言
- [x] JSXに`<button><Cancel/></button>`を追加


## 動作チェック
1. tsugumonにログイン　メールアドレス：[testuser@gmail.com](mailto:testuser@gmail.com)　パスワード：tesuuser

2. EditProfileForEnterprise.tsxが表示される → 下にスクロールすると、Upload.tsxの表示画面が見つかります。

3. 画像を選択します
<img width="1435" alt="スクリーンショット 2022-03-29 22 40 39" src="https://user-images.githubusercontent.com/98272835/160626280-7ff192b9-4f8a-48d3-b2c4-33ca87426f8e.png">

4. ❌ボタンをクリックします
<img width="1440" alt="スクリーンショット 2022-03-29 22 51 04" src="https://user-images.githubusercontent.com/98272835/160627085-6a693ae2-a5f0-4ff5-b23f-c8b65d4736db.png">

- [x] postImageがnullとなっていることを確認
- [x] postPreviewが空文字となっていることを確認

