### PR TITLE
✨ Uploadコンポーネントの表示・非表示を切り替えるボタンの実装

### DIFF
--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -23,20 +23,21 @@ const Feed = () => {
       {user.userType ? (
         <div>
           <EditProfileForEnterprise />
-          <button
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-              e.preventDefault();
-              setUploadOn(true);
-            }}
-          >
-            <AddCircle />
-          </button>
-          {uploadOn && (
+          {uploadOn ? (
             <Upload
               onClick={() => {
                 closeUpload();
               }}
             />
+          ) : (
+            <button
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+                setUploadOn(true);
+              }}
+            >
+              <AddCircle />
+            </button>
           )}
           <button
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { selectUser, logout, toggleIsNewUser } from "../../features/userSlice";
 import SelectUserType from "../SelectUserType/SelectUserType";
@@ -5,18 +6,38 @@ import { auth } from "../../firebase";
 import { signOut } from "firebase/auth";
 import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
 import Upload from "../Upload/Upload";
+import AddCircle from "@mui/icons-material/AddCircle";
 import React from "react";
 
 const Feed = () => {
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
+  const [uploadOn, setUploadOn] = useState<boolean>(false);
+
+  const closeUpload: () => void = () => {
+    setUploadOn(false);
+  };
 
   return (
     <>
       {user.userType ? (
         <div>
           <EditProfileForEnterprise />
-          <Upload />
+          <button
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              setUploadOn(true);
+            }}
+          >
+            <AddCircle />
+          </button>
+          {uploadOn && (
+            <Upload
+              onClick={() => {
+                closeUpload();
+              }}
+            />
+          )}
           <button
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               signOut(auth).catch((error: any) => {

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -4,7 +4,11 @@ import { selectUser, User } from "../../features/userSlice";
 import { useBatch } from "../../hooks/useBatch";
 import { AddPhotoAlternate, Cancel } from "@mui/icons-material";
 
-const Upload: React.FC = () => {
+interface Props {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const Upload = (props:Props) => {
   const user: User = useAppSelector(selectUser);
   const displayName: string = user.displayName;
   const avatarURL: string = user.photoURL;
@@ -72,7 +76,7 @@ const Upload: React.FC = () => {
   return (
     <div>
       <header>
-        <button id="cancel" type="button">
+        <button id="cancel" type="button" onClick={props.onClick}>
           キャンセルする
         </button>
         <p id="title">新規登録</p>
@@ -129,7 +133,9 @@ const Upload: React.FC = () => {
           value="投稿する"
           disabled={!postImage}
         />
-        <button id="cancelBottom">キャンセルする</button>
+        <button id="cancelBottom" onClick={props.onClick}>
+          キャンセルする
+        </button>
       </form>
       {progress === "run" && (
         <div id="modal">


### PR DESCRIPTION
## Issue
#88 

## 変更の内容
**Feed.tsx**
- [x] Material UI から AddCircle アイコンを追加インポート
- [x] Uploadコンポーネントの表示・非表示を管理するステート（`uploadOn`）を追加
- [x] ステート`uploadOn`を`false`に置き換える関数`closeUpload()`を作成
- [x] Uploadコンポーネントの表示・非表示を切り替えるボタンを作成

**Upload.tsx**
- [x] 型インターフェース`Props`を追加。
- [x] `Props`は、プロパティとしてonClickイベントに対するイベントハンドラを含みます
- [x] `<button id="cancel">`に`onClicke={props.onClick}`を追加
- [x] `<button id="cancelBottom">`に`onClicke={props.onClick}`を追加

## 動作チェック
1. tsugumonにログイン　メールアドレス：[testuser@gmail.com](mailto:testuser@gmail.com)　パスワード：testuser

2. Feedコンポーネントが表示される
<img width="1440" alt="スクリーンショット 2022-04-02 9 49 37" src="https://user-images.githubusercontent.com/98272835/161357771-d9bb44a8-b15b-45f9-a731-20cc99a383d1.png">

- [x] 画面左下に+ボタンが表示されているか確認
- [x] ステート`onUpload()`がfalseになっていることを確認

3. +ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-04-02 9 50 00" src="https://user-images.githubusercontent.com/98272835/161357954-3417c9e0-122d-42be-944f-42be8fd4ca55.png">

- [x] Uploadコンポーネントが表示されていることを確認
- [x] ステート`onUpload`がtrueになっていることを確認

4. キャンセルボタンをクリック
<img width="1440" alt="スクリーンショット 2022-04-02 9 50 12" src="https://user-images.githubusercontent.com/98272835/161358014-76686ebf-b171-41ce-a19e-04bd9c82cebd.png">

- [x] Uploadコンポーネントが非表示となっていることを確認
- [x] ステート`onUpload`がfalseになっていることを確認

5. ふたたび+ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-04-02 10 02 57" src="https://user-images.githubusercontent.com/98272835/161358095-c9d3a5c5-16e1-496b-a88b-3fddf70e7155.png">

6. Uploadコンポーネントの下部にある「キャンセル」ボタンをクリック

- [x] Uploadコンポーネントが非表示となっていることを確認
- [x] ステート`onUpload`がfalseになっていることを確認
 