### PR TITLE
✨ Uploadコンポーネントのキャンセルを確認するモーダル画面の実装

### DIFF
--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -8,7 +8,7 @@ interface Props {
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const Upload = (props:Props) => {
+const Upload = (props: Props) => {
   const user: User = useAppSelector(selectUser);
   const displayName: string = user.displayName;
   const avatarURL: string = user.photoURL;
@@ -17,6 +17,7 @@ const Upload = (props:Props) => {
   const [postPreview, setPostPreview] = useState<string>("");
   const [caption, setCaption] = useState<string>("");
   const [upload, setUpload] = useState<boolean>(false);
+  const [cancelModal, setCancelModal] = useState<boolean>(false);
   const progress: "wait" | "run" | "done" = useBatch(
     upload,
     postImage!,
@@ -76,7 +77,14 @@ const Upload = (props:Props) => {
   return (
     <div>
       <header>
-        <button id="cancel" type="button" onClick={props.onClick}>
+        <button
+          id="cancel"
+          type="button"
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            setCancelModal(true);
+          }}
+        >
           キャンセルする
         </button>
         <p id="title">新規登録</p>
@@ -133,7 +141,14 @@ const Upload = (props:Props) => {
           value="投稿する"
           disabled={!postImage}
         />
-        <button id="cancelBottom" onClick={props.onClick}>
+        <button
+          id="cancel"
+          type="button"
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            setCancelModal(true);
+          }}
+        >
           キャンセルする
         </button>
       </form>
@@ -145,6 +160,20 @@ const Upload = (props:Props) => {
       {progress === "done" && (
         <div id="toast">
           <p>アップロードが完了しました!</p>
+        </div>
+      )}
+      {cancelModal && (
+        <div id="cancelModal">
+          <p>画像の登録をキャンセルします。よろしいですか？</p>
+          <button onClick={props.onClick}>はい</button>
+          <button
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              setCancelModal(false);
+            }}
+          >
+            いいえ
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Issue
#90 

## 変更した内容
**Upload.tsx**
- [x] ステートに`canselModal`を追加
- [x] `<button id="cancel">` のonClickのイベントハンドラを変更
- [x] JSXに、キャンセル実行の意思を確認する要素を追加

## 動作チェック
1. tsugumonにログイン　メールアドレス：[testuser@gmail.com](mailto:testuser@gmail.com)　パスワード：testuser
2. 「+」ボタンをクリック → Uploadコンポーネントが表示されます。
<img width="1437" alt="スクリーンショット 2022-04-02 21 10 48" src="https://user-images.githubusercontent.com/98272835/161382610-68a0608f-b30d-4997-9dd8-8a21c05317ac.png">

- [x] ステート`cancelModal`がfalseになっていることを確認

3. Uploadコンポーネントのトップにある「キャンセルする」ボタンをクリック
<img width="1435" alt="スクリーンショット 2022-04-02 21 13 39" src="https://user-images.githubusercontent.com/98272835/161382921-5218cdd3-63e3-4975-bb08-9b3f5aa8d9c2.png">

- [x] ステート`cancelModal`がtrueになっていることを確認
- [x] モーダル部分が表示されているか確認 

4.「はい」ボタンをクリック

- [x] ステート`uploadOn`がfalseになっていることを確認
- [x] Uploadコンポーネントが非表示になっていることを確認

5. 「いいえ」ボタンをクリック

- [x] ステート`cancelModal`がfalseになっていることを確認
- [x] モーダル部分が非表示になっていることを確認

6.Uploadコンポーネントのボトムにある「キャンセルする」ボタンをクリック

7. 4~5のチェックを繰り返す
