### PR TITLE
✨ 表示画面の下地となるBasisコンポーネントを作成

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "./app/hooks";
 import { selectUser, login, logout } from "./features/userSlice";
-import Feed from "./components/Feed/Feed";
+import Basis from "./components/Basis/Basis";
 import UserAuthentication from "./components/UserAuthentication/UserAuthentication";
 import { auth, db } from "./firebase";
 import { onAuthStateChanged, Unsubscribe, User } from "firebase/auth";
@@ -56,6 +56,6 @@ const App: React.FC = () => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
-  return <>{user.uid ? <Feed /> : <UserAuthentication />}</>;
+  return <>{user.uid ? <Basis /> : <UserAuthentication />}</>;
 };
 export default App;

--- a/src/components/Basis/Basis.tsx
+++ b/src/components/Basis/Basis.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import Feed from "../Feed/Feed";
+import { Home, Search, Notifications, Email } from "@mui/icons-material";
+
+type Tab = "Feed" | "Search" | "Notifications" | "DM";
+const Basis: React.FC = () => {
+  const [tab, setTab] = useState<Tab>("Feed");
+  return (
+    <div>
+      {tab === "Feed" && <Feed />}
+      {tab === "Search" && <p>Search</p>}
+      {tab === "Notifications" && <p>Notifications</p>}
+      {tab === "DM" && <p>DM</p>}
+      <button
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.preventDefault();
+          setTab("Feed");
+        }}
+      >
+        <Home />
+      </button>
+      <button
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.preventDefault();
+          setTab("Search");
+        }}
+      >
+        <Search />
+      </button>
+      <button
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.preventDefault();
+          setTab("Notifications");
+        }}
+      >
+        <Notifications />
+      </button>
+      <button
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.preventDefault();
+          setTab("DM");
+        }}
+      >
+        <Email />
+      </button>
+    </div>
+  );
+};
+
+export default Basis;


### PR DESCRIPTION
## Issue
#92 

## 変更した内容
**App.tsx**
- [x] インポートするコンポーネントをFeed.tsxからBasis.tsxに変更
- [x] JSXの表示内容をFeedコンポーネントからBasisコンポーネントに変更

**Basis.tsx**
- [x] Material UI から Home,Search,Notifications,Email のアイコンをインポート
- [x] 選択したタブを管理するステート(`tab`)を作成
- [x] ステート(`tab`)の値に合わせて、画面表示が切り替わるよう、JSXに記述
- [x] Home,Search,Notification,Email それぞれのアイコンをボタンとして設定し、クリックされたら、該当するアイコン名がステートに記録されるよう記載

## 動作チェック

1. tsugumonにログイン
　メールアドレス：newUser@gmail.com
　パスワード　　：isNewUser

2.Basisコンポーネントが表示される
<img width="1440" alt="スクリーンショット 2022-04-03 22 49 17" src="https://user-images.githubusercontent.com/98272835/161431282-83fdf193-3edb-417c-82e4-9cd0f6890480.png">
- [x] 画面のボトムにHome,Search,Notifications,Emailの４つのタブを含むタブバーが存在しているか確認
- [x] Basisコンポーネントのステート`tab`が`"Feed"`となっていることを確認

3. 🔍アイコンをクリック
<img width="1440" alt="スクリーンショット 2022-04-03 22 55 12" src="https://user-images.githubusercontent.com/98272835/161431481-2de62f92-6cc7-4070-9fed-50a5e50b4acb.png">

- [x] 画面に`Search`の文字が表示されていることを確認
- [x] 画面のボトムにHome,Search,Notifications,DMの４つのタブを含むタブバーが存在しているか確認
- [x] Basisコンポーネントのステート`tab`が`"Search"`となっていることを確認

4. 🔔アイコンをクリック
- [x] 画面に`Notifications`の文字が表示されていることを確認
- [x] 画面のボトムにHome,Search,Notifications,DMの４つのタブを含むタブバーが存在しているか確認
- [x] Basisコンポーネントのステート`tab`が`"Notifications"`となっていることを確認

5.✉️ アイコンをクリック
- [x] 画面に`DM`の文字が表示されていることを確認
- [x] 画面のボトムにHome,Search,Notifications,Emailの４つのタブを含むタブバーが存在しているか確認
- [x] Basisコンポーネントのステート`tab`が`"Notifications"`となっていることを確認