### PR TITLE
✨ プロフィール閲覧画面（企業用）コンポーネントの雛形を作成

### DIFF
--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -4,7 +4,7 @@ import { selectUser, logout, toggleIsNewUser } from "../../features/userSlice";
 import SelectUserType from "../SelectUserType/SelectUserType";
 import { auth } from "../../firebase";
 import { signOut } from "firebase/auth";
-import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
+import ProfileForEnterprise from "../ProfileForEnterprise/ProfileForEnterprise";
 import Upload from "../Upload/Upload";
 import AddCircle from "@mui/icons-material/AddCircle";
 import React from "react";
@@ -22,7 +22,7 @@ const Feed = () => {
     <>
       {user.userType ? (
         <div>
-          <EditProfileForEnterprise />
+          <ProfileForEnterprise />
           {uploadOn ? (
             <Upload
               onClick={() => {

--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+const ProfileForEnterprise = () => {
+  return (
+    <div>
+      <div id="top">
+        <img id="background" alt="背景画像" />
+        <img id="avatar" alt="アバター画像" />
+        {/* TODO >> ログインユーザーがプロフィール画面のユーザーと異なる場合には、
+                    「フォロー」ボタンを表示するようにする  */}
+        <button>編集する</button>
+      </div>
+      <div id="profile">
+        <p id="introduction">説明文</p>
+        <button>さらに表示</button>
+        <div id="followerCount">
+          <p>フォロワー</p>
+          <p>人</p>
+        </div>
+        <div id="followeeCount">
+          <p>フォロー中</p>
+          <p>人</p>
+        </div>
+        <div>
+          <p id="owner"></p>
+        </div>
+        <div>
+          <p id="typeOfWork"></p>
+        </div>
+        <div>
+          <p id="address"></p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileForEnterprise;


### PR DESCRIPTION
## Issue
#95 

## 変更した内容

- [x] 「ProfileForEnterprise」の名前で、新しいコンポーネントを作成する
- [x] 画面デザイン案を参考に、ProfileForEnterpriseで表示するJSXを記述する
- [x] Feedコンポーネントの内容を書き換えて、EditProfileForEnterpriseの代わりにProfileForEnterpriseコンポーネントを表示するようにする

## 動作チェック
- [x] EditProfileForEnterpriseの代わりにProfileForEnterpriseコンポーネントが表示されることを確認