### PR TITLE
✨ プロフィール閲覧画面と編集画面を切り替えるボタンの実装

### DIFF
--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -18,7 +18,11 @@ import {
   uploadBytesResumable,
 } from "firebase/storage";
 
-const EditProfileForEnterprise = () => {
+interface Props {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const EditProfileForEnterprise: (props: Props) => JSX.Element = (props) => {
   const [displayName, setDisplayName] = useState<string>("");
   const [introduction, setIntroduction] = useState<string>("");
   const [avatarURL, setAvatarURL] = useState<string>("");
@@ -200,6 +204,12 @@ const EditProfileForEnterprise = () => {
 
   return (
     <div>
+      <header>
+        <button id="cancel" onClick={props.onClick}>
+          キャンセルする
+        </button>
+        <p>編集画面</p>
+      </header>
       <div id="backgroundSection">
         <div>
           <img

--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -1,35 +1,62 @@
-import React from "react";
-const ProfileForEnterprise = () => {
+import React, { useState } from "react";
+import { useAppSelector } from "../../app/hooks";
+import { selectUser } from "../../features/userSlice";
+import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
+const ProfileForEnterprise: React.FC = () => {
+  const user = useAppSelector(selectUser);
+  const [edit, setEdit] = useState<boolean>(false);
+  const closeEdit: () => void = () => {
+    setEdit(false);
+  };
   return (
     <div>
-      <div id="top">
-        <img id="background" alt="背景画像" />
-        <img id="avatar" alt="アバター画像" />
-        {/* TODO >> ログインユーザーがプロフィール画面のユーザーと異なる場合には、
-                    「フォロー」ボタンを表示するようにする  */}
-        <button>編集する</button>
-      </div>
-      <div id="profile">
-        <p id="introduction">説明文</p>
-        <button>さらに表示</button>
-        <div id="followerCount">
-          <p>フォロワー</p>
-          <p>人</p>
-        </div>
-        <div id="followeeCount">
-          <p>フォロー中</p>
-          <p>人</p>
-        </div>
-        <div>
-          <p id="owner"></p>
-        </div>
-        <div>
-          <p id="typeOfWork"></p>
-        </div>
-        <div>
-          <p id="address"></p>
-        </div>
-      </div>
+      {(user.isNewUser || edit) && (
+        <EditProfileForEnterprise
+          onClick={() => {
+            closeEdit();
+          }}
+        />
+      )}
+      {!user.isNewUser && !edit && (
+        <>
+          <div id="top">
+            <img id="background" alt="背景画像" />
+            <img id="avatar" alt="アバター画像" />
+            {/* TODO >> ログインユーザーがプロフィール画面のユーザーと
+                        異なる場合には、「フォロー」ボタンを表示するようにする  */}
+            <button
+              id="toEditProfile"
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+                setEdit(true);
+              }}
+            >
+              編集する
+            </button>
+          </div>
+          <div id="profile">
+            <p id="introduction">説明文</p>
+            <button>さらに表示</button>
+            <div id="followerCount">
+              <p>フォロワー</p>
+              <p>人</p>
+            </div>
+            <div id="followeeCount">
+              <p>フォロー中</p>
+              <p>人</p>
+            </div>
+            <div>
+              <p id="owner"></p>
+            </div>
+            <div>
+              <p id="typeOfWork"></p>
+            </div>
+            <div>
+              <p id="address"></p>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Issue
#97 
## 変更した内容

**EditProfileForEnterprise**

- [x] `onClick`のイベントハンドラを含む`interface Props`の追加
- [x] 関数コンポーネント「**EditProfileForEnterprise**」の引数にpropsを追加
- [x] 「キャンセルする」ボタンをクリックした際に、`props.onClick`がトリガーされるように、JSXを修正

**ProfileForEnterprise**

- [x] `user.isNewUser`が**true**、またはステート`edit`が**true**の場合に**EditProfileForEnterprise**が表示されるよう、JSXを修正
- [x] `user.isNewUser`が**false**、かつステート`edit`が**false**の場合に**ProfileForEnterprise**の画面が表示されるよう、JSXを修正
- [x] 新たな関数`closeEdit()`を追加し、**EditProfileForEnterprise**にpropsとして渡す

## 動作チェック
1. tsugumonにログイン
　メールアドレス：[newUser@gmail.com](mailto:newUser@gmail.com)
　パスワード　　：isNewUser

2.Basisコンポーネントが表示されるので、「編集する」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-04-07 0 07 35" src="https://user-images.githubusercontent.com/98272835/162009406-1bbd9bc8-45e5-4358-b111-e55018a45c98.png">

- [x] EditProfileForEnterpriseコンポーネントが表示されることを確認

3. 「キャンセルする」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-04-07 0 07 51" src="https://user-images.githubusercontent.com/98272835/162009921-8324d1da-c1cf-4497-8369-17a35ec98acf.png">

- [x] EditProfileForEnterpriseコンポーネントが非表示となることを確認
