### PR TITLE
🐛 プロフィール編集画面上の「キャンセル」ボタンのエラーを解決

### DIFF
--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -1,62 +1,69 @@
-import React, { useState } from "react";
-import { useAppSelector } from "../../app/hooks";
-import { selectUser } from "../../features/userSlice";
+import React, { useState, useEffect } from "react";
+import { useAppSelector, useAppDispatch } from "../../app/hooks";
+import { selectUser, toggleIsNewUser } from "../../features/userSlice";
 import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
 const ProfileForEnterprise: React.FC = () => {
   const user = useAppSelector(selectUser);
+  const dispatch = useAppDispatch();
   const [edit, setEdit] = useState<boolean>(false);
   const closeEdit: () => void = () => {
     setEdit(false);
   };
+  useEffect(() => {
+    if (user.isNewUser) {
+      setEdit(true);
+    }
+    return () => {
+      dispatch(toggleIsNewUser(false));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div>
-      {(user.isNewUser || edit) && (
+      {edit && (
         <EditProfileForEnterprise
           onClick={() => {
             closeEdit();
           }}
         />
       )}
-      {!user.isNewUser && !edit && (
-        <>
-          <div id="top">
-            <img id="background" alt="背景画像" />
-            <img id="avatar" alt="アバター画像" />
-            {/* TODO >> ログインユーザーがプロフィール画面のユーザーと
+      <div id="top">
+        <img id="background" alt="背景画像" />
+        <img id="avatar" alt="アバター画像" />
+        {/* TODO >> ログインユーザーがプロフィール画面のユーザーと
                         異なる場合には、「フォロー」ボタンを表示するようにする  */}
-            <button
-              id="toEditProfile"
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                e.preventDefault();
-                setEdit(true);
-              }}
-            >
-              編集する
-            </button>
-          </div>
-          <div id="profile">
-            <p id="introduction">説明文</p>
-            <button>さらに表示</button>
-            <div id="followerCount">
-              <p>フォロワー</p>
-              <p>人</p>
-            </div>
-            <div id="followeeCount">
-              <p>フォロー中</p>
-              <p>人</p>
-            </div>
-            <div>
-              <p id="owner"></p>
-            </div>
-            <div>
-              <p id="typeOfWork"></p>
-            </div>
-            <div>
-              <p id="address"></p>
-            </div>
-          </div>
-        </>
-      )}
+        <button
+          id="toEditProfile"
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            setEdit(true);
+          }}
+        >
+          編集する
+        </button>
+      </div>
+      <div id="profile">
+        <p id="introduction">説明文</p>
+        <button>さらに表示</button>
+        <div id="followerCount">
+          <p>フォロワー</p>
+          <p>人</p>
+        </div>
+        <div id="followeeCount">
+          <p>フォロー中</p>
+          <p>人</p>
+        </div>
+        <div>
+          <p id="owner"></p>
+        </div>
+        <div>
+          <p id="typeOfWork"></p>
+        </div>
+        <div>
+          <p id="address"></p>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Issue
#99 

## 変更した内容
**ProfileForEnterprise.tsx**
- [x] `useEffect()`の処理を追加
- [x] `useEffect()`内で、Reduxのステート`isNewUser`が**true**の場合、`setEdit(true)`を実行するよう設定
- [x] `useEffect()`内で、クリーンアップ関数として`dispatch(toggleIsNewUser(false))`を設定
- [x] editがtrueのときのみ、EditProfileForEnterpriseコンポーネントを表示するよう、JSXの条件を変更。
- [x] ProfileForEnterprise.tsxの要素を表示するための条件づけを削除

## 動作チェック
1. ログイン画面の「新規登録」をクリック
2. 新しいユーザーアカウントを登録
3. SelectUserTypeコンポーネントで「企業ユーザー」を選択 → 「この内容で登録する」をクリック
4. プロフィール編集画面（企業用）が表示される

<img width="1433" alt="スクリーンショット 2022-04-07 23 35 36" src="https://user-images.githubusercontent.com/98272835/162224630-6847355f-d11a-49f0-ba7e-db293e98e4b4.png">

 - [x] Reduxのステート`isNewUser`が**true**になっていることを確認
 - [x] **EditProfileForEnterprise.tsx**のステート`edit`が**true**になっていることを確認

5.「キャンセルする」をクリック

<img width="1435" alt="スクリーンショット 2022-04-07 23 38 28" src="https://user-images.githubusercontent.com/98272835/162226154-e39d510d-a7f1-4caa-8341-3df5819e5d81.png">

- [x] **EditProfileForEnterprise.tsx**のコンポーネントが閉じることを確認
- [x] Reduxのステート`isNewUser`が**true**になっていることを確認
- [x] **EditProfileForEnterprise.tsx**のステート`edit`が**false**になっていることを確認