### PR TITLE
✨ FirestoreとStorageに登録されているデータをプロフィール画面に表示

### DIFF
--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -59,7 +59,7 @@ const ProfileForEnterprise: React.FC = () => {
     getUser();
     getEnterprise();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [edit]);
 
   const closeEdit: () => void = () => {
     setEdit(false);
@@ -85,7 +85,11 @@ const ProfileForEnterprise: React.FC = () => {
       )}
       <div id="top">
         <img id="background" src={backgroundURL} alt="背景画像" />
-        <img id="avatar" src={avatarURL} alt="アバター画像" />
+        <img
+          id="avatar"
+          src={avatarURL ? avatarURL : `${process.env.PUBLIC_URL}/noAvatar.png`}
+          alt="アバター画像"
+        />
         <p id="displayName">{displayName}</p>
         {/* TODO >> ログインユーザーがプロフィール画面のユーザーと
                         異なる場合には、「フォロー」ボタンを表示するようにする  */}
@@ -101,24 +105,28 @@ const ProfileForEnterprise: React.FC = () => {
       </div>
       <div id="profile">
         <div id="introduction">
+          <p>紹介文</p>
           <p>{introduction}</p>
           <button>さらに表示</button>
         </div>
         <div id="followerCount">
           <p>フォロワー</p>
-          <p>人</p>
+          <p>０人</p>
         </div>
         <div id="followeeCount">
           <p>フォロー中</p>
-          <p>人</p>
+          <p>０人</p>
         </div>
         <div id="owner">
+          <p>事業主</p>
           <p>{owner}</p>
         </div>
         <div id="typeOfWork">
+          <p>職種</p>
           <p>{typeOfWork}</p>
         </div>
         <div id="address">
+          <p>住所</p>
           <p>{address}</p>
         </div>
       </div>

--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -1,11 +1,66 @@
 import React, { useState, useEffect } from "react";
 import { useAppSelector, useAppDispatch } from "../../app/hooks";
 import { selectUser, toggleIsNewUser } from "../../features/userSlice";
+import { db } from "../../firebase";
+import {
+  doc,
+  DocumentData,
+  DocumentReference,
+  getDoc,
+} from "firebase/firestore";
 import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
+
 const ProfileForEnterprise: React.FC = () => {
-  const user = useAppSelector(selectUser);
-  const dispatch = useAppDispatch();
   const [edit, setEdit] = useState<boolean>(false);
+  const [displayName, setDisplayName] = useState<string>("");
+  const [introduction, setIntroduction] = useState<string>("");
+  const [avatarURL, setAvataraURL] = useState<string>("");
+  const [backgroundURL, setBackgroundURL] = useState<string>("");
+  const [owner, setOwner] = useState<string>("");
+  const [typeOfWork, setTypeOfWork] = useState<string>("");
+  const [address, setAddress] = useState<string>("");
+
+  const dispatch = useAppDispatch();
+  const user = useAppSelector(selectUser);
+  const userRef: DocumentReference<DocumentData> = doc(
+    db,
+    "users",
+    `${user.uid}`
+  );
+  const enterpriseRef: DocumentReference<DocumentData> = doc(
+    db,
+    "users",
+    `${user.uid}`,
+    "enterprise",
+    `${user.uid}`
+  );
+  const getUser: () => Promise<void> = async () => {
+    const userSnap = await getDoc(userRef);
+    if (userSnap) {
+      setDisplayName(userSnap.data()!.displayName);
+      setAvataraURL(userSnap.data()!.photoURL);
+    }
+  };
+  const getEnterprise: () => Promise<void> = async () => {
+    const enterpriseSnap = await getDoc(enterpriseRef);
+    if (enterpriseSnap) {
+      setIntroduction(enterpriseSnap.data()!.introduction);
+      setBackgroundURL(enterpriseSnap.data()!.backgroundURL);
+      setOwner(enterpriseSnap.data()!.owner);
+      setTypeOfWork(enterpriseSnap.data()!.typeOfWork);
+      setAddress(enterpriseSnap.data()!.address);
+    }
+  };
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "development") {
+      console.log("useEffectが実行されました");
+    }
+    getUser();
+    getEnterprise();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const closeEdit: () => void = () => {
     setEdit(false);
   };
@@ -29,8 +84,9 @@ const ProfileForEnterprise: React.FC = () => {
         />
       )}
       <div id="top">
-        <img id="background" alt="背景画像" />
-        <img id="avatar" alt="アバター画像" />
+        <img id="background" src={backgroundURL} alt="背景画像" />
+        <img id="avatar" src={avatarURL} alt="アバター画像" />
+        <p id="displayName">{displayName}</p>
         {/* TODO >> ログインユーザーがプロフィール画面のユーザーと
                         異なる場合には、「フォロー」ボタンを表示するようにする  */}
         <button
@@ -44,8 +100,10 @@ const ProfileForEnterprise: React.FC = () => {
         </button>
       </div>
       <div id="profile">
-        <p id="introduction">説明文</p>
-        <button>さらに表示</button>
+        <div id="introduction">
+          <p>{introduction}</p>
+          <button>さらに表示</button>
+        </div>
         <div id="followerCount">
           <p>フォロワー</p>
           <p>人</p>
@@ -54,14 +112,14 @@ const ProfileForEnterprise: React.FC = () => {
           <p>フォロー中</p>
           <p>人</p>
         </div>
-        <div>
-          <p id="owner"></p>
+        <div id="owner">
+          <p>{owner}</p>
         </div>
-        <div>
-          <p id="typeOfWork"></p>
+        <div id="typeOfWork">
+          <p>{typeOfWork}</p>
         </div>
-        <div>
-          <p id="address"></p>
+        <div id="address">
+          <p>{address}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Issue
#101 

## 変更した内容
- [x] Firebaseから新しいモジュールをインポート
- [x] プロフィール閲覧画面に表示するテキスト情報や画像URLを管理するため、ステートを追加
- [x] Firestoreのusersコレクションのドキュメントを参照する変数`userRef`を追加
- [x] Firestoreのenterpriseコレクションのドキュメントを参照する変数`enterpriseRef`を追加
- [x] `userRef`から情報を取得する関数`getUser`を追加
- [x] `enterpriseRef`から情報を取得する関数`getEnterprise`を追加
- [x] `useEffect()`を追加し、レンダリング時に`getUser`と`getEnterprise`を実行するよう設定
- [x] JSXにステートの値を表示するよう変更
- [x] プロフィール編集画面の表示・非表示を管理するステート`edit`が変化したら、`useEffect()`が実行されるよう設定

## 動作チェック

1. tsugumonにログイン

　メールアドレス：[newUser@gmail.com](mailto:newUser@gmail.com)
　パスワード　　：isNewUser

2. プロフィール閲覧画面が表示される

<img width="1440" alt="スクリーンショット 2022-04-10 14 02 41" src="https://user-images.githubusercontent.com/98272835/162602272-10b404ce-e64a-4842-ac44-5be1661c2d9b.png">

 - [x] JSXの各項目について、Firestoreの情報が正確に表示されているか
 - [x] アバター画像と背景画像が表示されているか
 
3. 「編集する」ボタンをクリック

<img width="1440" alt="スクリーンショット 2022-04-10 14 08 56" src="https://user-images.githubusercontent.com/98272835/162602374-f0cfe51c-9f46-4f58-9d19-76e99e3aada7.png">

4. 「アバター画像」または「背景画像」を変更
5. 「キャンセルする」をクリック
6. ふたたびプロフィール閲覧画面が表示される
<img width="1440" alt="スクリーンショット 2022-04-10 14 11 24" src="https://user-images.githubusercontent.com/98272835/162602423-45b62770-114c-4d68-8d50-6089b6bcb280.png">

- [x] 4.のとき編集した内容が反映されているか確認

7. 「編集する」ボタンをクリック
8. テキスト情報を変更
9. 「キャンセルする」をクリック
10. ふたたびプロフィール閲覧画面が表示される
- [x] 8.のとき編集した内容が反映されているか確認
