### PR TITLE
👍 プロフィール編集画面で登録したら画面が閉じるようコードを修正

### DIFF
--- a/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
+++ b/src/components/EditProfileForEnterprise/EditProfileForEnterprise.tsx
@@ -19,7 +19,7 @@ import {
 } from "firebase/storage";
 
 interface Props {
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  closeEdit:()=>void;
 }
 
 const EditProfileForEnterprise: (props: Props) => JSX.Element = (props) => {
@@ -172,6 +172,7 @@ const EditProfileForEnterprise: (props: Props) => JSX.Element = (props) => {
         photoURL: avatarURL,
       })
     );
+    props.closeEdit();
   };
 
   const deleteImage: (
@@ -205,7 +206,7 @@ const EditProfileForEnterprise: (props: Props) => JSX.Element = (props) => {
   return (
     <div>
       <header>
-        <button id="cancel" onClick={props.onClick}>
+        <button id="cancel" onClick={props.closeEdit}>
           キャンセルする
         </button>
         <p>編集画面</p>
@@ -407,7 +408,7 @@ const EditProfileForEnterprise: (props: Props) => JSX.Element = (props) => {
           />
         </div>
         <div>
-          <input type="submit" data-testid="submitProfile" value="登録する" />
+          <input type="submit" data-testid="submitProfile" value="登録する"/>
         </div>
       </form>
     </div>

--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -76,13 +76,7 @@ const ProfileForEnterprise: React.FC = () => {
 
   return (
     <div>
-      {edit && (
-        <EditProfileForEnterprise
-          onClick={() => {
-            closeEdit();
-          }}
-        />
-      )}
+      {edit && <EditProfileForEnterprise closeEdit={closeEdit} />}
       <div id="top">
         <img id="background" src={backgroundURL} alt="背景画像" />
         <img


### PR DESCRIPTION
## Issue
#103 

## 変更した内容

**EditProfileForEnterprise.tsx**
- [x] interface`Props`を修正(onClickを削除。closeEditを追加)
- [x] 関数`editProfil`eの最後に`props.closeEdit`を追加
- [x] onClickイベントハンドラの代わりに関数`props.closeEdit`を渡すよう変更

**ProfileForEnterprise.tsx**
- [x] onClickイベントハンドラの代わりに関数`closeEdit`を渡すようpropsを修正

## 動作チェック

1. tsugumonにログイン　メールアドレス：newUser@gmail.com　パスワード：isNewUser
2. プロフィール閲覧画面が表示されるので、「編集する」ボタンをクリック
3. アバター画像、または背景画像を変更 
- [x] 「登録する」ボタンをクリック → **EditProfileForEnterprise.tsx**が自動的に閉じるか確認
- [x] 「キャンセルする」ボタンをクリック → **EditProfileForEnterprise.tsx**が閉じるか確認
4. 「編集する」ボタンをクリック
5. テキスト情報を変更
- [x] 「登録する」ボタンをクリック → **EditProfileForEnterprise.tsx**が自動的に閉じるか確認
- [x] 「キャンセルする」ボタンをクリック → **EditProfileForEnterprise.tsx**が閉じるか確認
