### PR TITLE
✨ 過去投稿した画像を表示する新しいコンポーネントの雛形を作成

### DIFF
--- a/src/components/PastPost/PastPost.tsx
+++ b/src/components/PastPost/PastPost.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Favorite } from "@mui/icons-material";
+
+const PastPost: () => JSX.Element = () => {
+  return (
+    <div>
+      <div>
+        <img alt="投稿画像" />
+        <div>
+          <Favorite />
+          <p id="likeCounts">0</p>
+        </div>
+      </div>
+      <div>
+        <img alt="アバター画像" />
+        <p id="displayName">株式会社○○</p>
+      </div>
+      <div>
+        <p id="caption">キャプション</p>
+      </div>
+    </div>
+  );
+};
+
+export default PastPost;

--- a/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
+++ b/src/components/ProfileForEnterprise/ProfileForEnterprise.tsx
@@ -9,6 +9,7 @@ import {
   getDoc,
 } from "firebase/firestore";
 import EditProfileForEnterprise from "../EditProfileForEnterprise/EditProfileForEnterprise";
+import PastPost from "../PastPost/PastPost";
 
 const ProfileForEnterprise: React.FC = () => {
   const [edit, setEdit] = useState<boolean>(false);
@@ -19,6 +20,7 @@ const ProfileForEnterprise: React.FC = () => {
   const [owner, setOwner] = useState<string>("");
   const [typeOfWork, setTypeOfWork] = useState<string>("");
   const [address, setAddress] = useState<string>("");
+  const [tab, setTab] = useState<"posts" | "advertise">("posts");
 
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
@@ -124,6 +126,26 @@ const ProfileForEnterprise: React.FC = () => {
           <p>{address}</p>
         </div>
       </div>
+      <div>
+        <button
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            setTab("posts");
+          }}
+        >
+          投稿
+        </button>
+        <button
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            setTab("advertise");
+          }}
+        >
+          募集
+        </button>
+      </div>
+      {tab === "posts" && <PastPost />}
+      {tab === "advertise" && <p>advertise</p>}
     </div>
   );
 };


### PR DESCRIPTION
## Issue
#105 

## 変更した内容
**PastPost.tsx**
- [x] materialUIからFavoriteアイコンをインポート
- [x] Firestoreから取得してきた投稿データを表示するJSXの雛形を作成
(注）`map()`を使ってFirestoreからの取得情報をJSXに展開する予定

**ProfileForEnterprise.tsx**
- [x] **PastPost.tsx**をインポート
- [x] JSXに`<PastPost />`を追加
- [x] 「投稿」か「募集」かどちらを表示するか選択できるよう、ステート`tab`を追加


## 動作チェック

1. tsugumonにログイン
　メールアドレス：[newUser@gmail.com](mailto:newUser@gmail.com)
　パスワード　　：isNewUser

2. プロフィール閲覧画面が表示される

![スクリーンショット 2022-04-10 22 50 46（2）](https://user-images.githubusercontent.com/98272835/162621461-8eb506cd-d569-4a8f-8537-4958c3cfe245.png)

- [x] **PastPost.tsx**の内容が表示されていることを確認

3. 「募集」ボタンをクリック

- [x] 画面上に「adverttise」の文字が表示されることを確認

4. [投稿」ボタンをクリック  

- [x] **PastPost.tsx**の内容が表示されることを確認