### PR TITLE
✨ ユーザープロフィールの表示・非表示を切り替えるボタンの実装

### DIFF
--- a/src/components/BusinessUser/BusinessUser.tsx
+++ b/src/components/BusinessUser/BusinessUser.tsx
@@ -11,7 +11,11 @@ import {
 import EditProfileForEnterprise from "../EditBusinessUser/EditBusinessUser";
 import MyPosts from "../MyPosts/MyPosts";
 
-const BusinessUser: React.FC = () => {
+interface Props {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const BusinessUser = (props: Props) => {
   const [edit, setEdit] = useState<boolean>(false);
   const [displayName, setDisplayName] = useState<string>("");
   const [introduction, setIntroduction] = useState<string>("");
@@ -80,6 +84,7 @@ const BusinessUser: React.FC = () => {
     <div>
       {edit && <EditProfileForEnterprise closeEdit={closeEdit} />}
       <div id="top">
+        <button onClick={props.onClick}>閉じる</button> 
         <img id="background" src={backgroundURL} alt="背景画像" />
         <img
           id="avatar"

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -26,8 +26,12 @@ const Feed = () => {
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
   const [uploadOn, setUploadOn] = useState<boolean>(false);
+  const [profileOn, setProfileOn] = useState<boolean>(false);
   const closeUpload: () => void = () => {
     setUploadOn(false);
+  };
+  const closeProfile: () => void = () => {
+    setProfileOn(false);
   };
   const feeds: PostData[] = useFeeds();
   if (process.env.NODE_ENV === "development") {
@@ -51,7 +55,22 @@ const Feed = () => {
               />
             );
           })}
-          <BusinessUser />
+          {profileOn ? (
+            <BusinessUser
+              onClick={() => {
+                closeProfile();
+              }}
+            />
+          ) : (
+            <button
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+                setProfileOn(true);
+              }}
+            >
+              プロフィール表示
+            </button>
+          )}
           {uploadOn ? (
             <Upload
               onClick={() => {


### PR DESCRIPTION
## Issue
#125 

## 変更した内容
**src/components/Feed/Feed.tsx**
- ユーザープロフィールの表示・非表示を管理するステート`profileOn`を追加
- ステート`profileOn`を書き換える関数`closeProfile`を追加
- `<BusinessUser>` にpropsとしてonClickイベントハンドラを渡す

**src/components/BusinessUser/BusinessUser.tsx**
- インターフェースPropsを追加
- PropsのプロパティとしてonClickイベントハンドラを追加
- 閉じるボタンをクリックした際、propsのonClickイベントハンドラが起動するよう設定

## 動作チェック
- [x] 「プロフィール表示」ボタンをクリックした際、ユーザープロフィール画面が表示されることを確認
- [x] 「閉じる」ボタンをクリックした際、ユーザープロフィール画面が閉じることを確認