### PR TITLE
🚀 Feedコンポーネントに関する再レンダリングの最適化を実行

### DIFF
--- a/src/components/BusinessUser/BusinessUser.tsx
+++ b/src/components/BusinessUser/BusinessUser.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, memo } from "react";
 import { useAppSelector, useAppDispatch } from "../../app/hooks";
 import { selectUser, toggleIsNewUser } from "../../features/userSlice";
 import { db } from "../../firebase";
@@ -12,10 +12,14 @@ import EditProfileForEnterprise from "../EditBusinessUser/EditBusinessUser";
 import MyPosts from "../MyPosts/MyPosts";
 
 interface Props {
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  closeProfile: () => void;
 }
 
-const BusinessUser = (props: Props) => {
+const BusinessUser = memo((props: Props) => {
+  if (process.env.NODE_ENV === "development") {
+    console.log("BusinessUser.tsxがレンダリングされました");
+  }
+  const closeProfile = props.closeProfile;
   const [edit, setEdit] = useState<boolean>(false);
   const [displayName, setDisplayName] = useState<string>("");
   const [introduction, setIntroduction] = useState<string>("");
@@ -84,7 +88,7 @@ const BusinessUser = (props: Props) => {
     <div>
       {edit && <EditProfileForEnterprise closeEdit={closeEdit} />}
       <div id="top">
-        <button onClick={props.onClick}>閉じる</button> 
+        <button onClick={closeProfile}>閉じる</button>
         <img id="background" src={backgroundURL} alt="背景画像" />
         <img
           id="avatar"
@@ -153,6 +157,6 @@ const BusinessUser = (props: Props) => {
       {tab === "advertise" && <p>advertise</p>}
     </div>
   );
-};
+});
 
 export default BusinessUser;

--- a/src/components/MyPosts/MyPosts.tsx
+++ b/src/components/MyPosts/MyPosts.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, memo } from "react";
 import Post from "../Post/Post";
 import { usePosts } from "../../hooks/usePosts";
 import { useDemo } from "../../hooks/useDemo";
@@ -13,7 +13,10 @@ interface PostData {
   updatedAt: any;
 }
 
-const MyPosts = () => {
+const MyPosts = memo(() => {
+  if (process.env.NODE_ENV === "development") {
+    console.log("MyPostsがレンダリングされました");
+  }
   const [uploadDemo, setUploadDemo] = useState<boolean>(false);
   const progress: "wait" | "run" | "done" = useDemo(uploadDemo);
   const posts: PostData[] = usePosts();
@@ -27,7 +30,7 @@ const MyPosts = () => {
         break;
       case "run":
         if (process.env.NODE_ENV === "development") {
-          console.log(`${progress}: アップロードの実行中`)
+          console.log(`${progress}: アップロードの実行中`);
         }
         break;
       case "done":
@@ -63,6 +66,6 @@ const MyPosts = () => {
       })}
     </>
   );
-};
+});
 
 export default MyPosts;

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Favorite } from "@mui/icons-material";
 interface Props {
   key: string;
@@ -9,26 +10,30 @@ interface Props {
   updatedAt: any;
 }
 
-const Post= (props:Props) => {
+const Post = memo((props: Props) => {
+  const { displayName, avatarURL, imageURL, caption, updatedAt } = props;
+  if (process.env.NODE_ENV === "development") {
+    console.log("Post.tsxがレンダリングされました");
+  }
   return (
     <div>
       <div>
-        <p id="displayName">{props.displayName}</p>
-        <p id="updatedAt">{props.updatedAt}</p>
-        <img id="avatarURL" src={props.avatarURL} alt="アバター画像" />
+        <p id="displayName">{displayName}</p>
+        <p id="updatedAt">{updatedAt}</p>
+        <img id="avatarURL" src={avatarURL} alt="アバター画像" />
       </div>
       <div>
-        <img id="image" src={props.imageURL} alt="投稿画像" />
+        <img id="image" src={imageURL} alt="投稿画像" />
         <div>
           <Favorite />
           <p id="likeCounts">0</p>
         </div>
       </div>
       <div>
-        <p id="caption">{props.caption}</p>
+        <p id="caption">{caption}</p>
       </div>
     </div>
   );
-};
+});
 
 export default Post;

--- a/src/components/SelectUserType/SelectUserType.tsx
+++ b/src/components/SelectUserType/SelectUserType.tsx
@@ -6,6 +6,9 @@ import { signOut } from "firebase/auth";
 import { doc, updateDoc } from "firebase/firestore";
 
 const SelectUserType = () => {
+  if (process.env.NODE_ENV === "development") {
+    console.log("SelectUserTypeがレンダリングされました");
+  }
   const [userType, setUserType] = useState<
     "businessUser" | "normalUser" | null
   >(null);

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -1,14 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, memo } from "react";
 import { useAppSelector } from "../../app/hooks";
 import { selectUser, User } from "../../features/userSlice";
 import { useBatch } from "../../hooks/useBatch";
 import { AddPhotoAlternate, Cancel } from "@mui/icons-material";
 
 interface Props {
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  closeUpload: () => void;
 }
 
-const Upload = (props: Props) => {
+const Upload: React.FC<Props> = memo((props) => {
+  if (process.env.NODE_ENV === "development") {
+    console.log("Upload.tsxがレンダリングされました");
+  }
+  const closeUpload = props.closeUpload;
   const user: User = useAppSelector(selectUser);
   const displayName: string = user.displayName;
   const avatarURL: string = user.avatarURL;
@@ -165,7 +169,7 @@ const Upload = (props: Props) => {
       {cancelModal && (
         <div id="cancelModal">
           <p>画像の登録をキャンセルします。よろしいですか？</p>
-          <button onClick={props.onClick}>はい</button>
+          <button onClick={closeUpload}>はい</button>
           <button
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
@@ -178,6 +182,6 @@ const Upload = (props: Props) => {
       )}
     </div>
   );
-};
+});
 
 export default Upload;

--- a/src/hooks/useDemo.ts
+++ b/src/hooks/useDemo.ts
@@ -74,7 +74,7 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
     await fetchData();
     if (fetchedData.length > 0) {
       fetchedData.forEach(async (data) => {
-        const uid:string = data.uid
+        const uid: string = data.uid;
         const filename: string = getRandomString();
         const imageRef: StorageReference = ref(
           storage,
@@ -135,6 +135,9 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
     } else {
       setProgress("wait");
     }
+    return () => {
+      setProgress("wait");
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uploadDemo]);
   return progress;

--- a/src/hooks/useFeeds.ts
+++ b/src/hooks/useFeeds.ts
@@ -24,7 +24,10 @@ interface PostData {
   updatedTime: number;
 }
 
-export const useFeeds = () => {
+export const useFeeds: () => PostData[] = () => {
+  if (process.env.NODE_ENV === "development") {
+    console.log("useFeeds.tsがレンダリングされました");
+  }
   const user: User = useAppSelector(selectUser);
   const [feeds, setFeeds] = useState<PostData[]>([]);
   let updatedFeeds: PostData[] = [];
@@ -50,6 +53,9 @@ export const useFeeds = () => {
         onSnapshot(
           feedsQuery,
           (snapshots: QuerySnapshot<DocumentData>) => {
+            if (process.env.NODE_ENV === "development") {
+              console.log("onSnapshotが実行されました");
+            }
             const followeeFeeds: PostData[] = snapshots.docs.map(
               (snapshot: QueryDocumentSnapshot<DocumentData>) => {
                 const updatedTime: number = snapshot.data().updatedAt.seconds;
@@ -99,6 +105,7 @@ export const useFeeds = () => {
     unsubscribe();
     return () => {
       unsubscribe();
+      console.log("クリーンアップ関数が実行されました");
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -26,54 +26,57 @@ interface PostData {
 export const usePosts: () => PostData[] = () => {
   const user: User = useAppSelector(selectUser);
   const [posts, setPosts] = useState<PostData[]>([]);
-
   const postsQuery: Query<DocumentData> = query(
     collection(db, `users/${user.uid}/businessUser/${user.uid}/posts`)
   );
 
+  const unsubscribe: () => void = () => {
+    onSnapshot(postsQuery, (snapshots: QuerySnapshot<DocumentData>) => {
+      if (process.env.NODE_ENV === "development") {
+        console.log("onSnapshotが実行されました");
+      }
+      const updatedPosts = snapshots.docs.map(
+        (snapshot: QueryDocumentSnapshot<DocumentData>) => {
+          const updatedTime = snapshot.data().updatedAt.seconds;
+          const updatedDate = snapshot.data().updatedAt.toDate();
+          const updatedAt =
+            updatedDate.getFullYear() +
+            "年" +
+            ("0" + updatedDate.getMonth()).slice(-2) +
+            "月" +
+            ("0" + updatedDate.getDate()).slice(-2) +
+            "日" +
+            " " +
+            ("0" + updatedDate.getHours()).slice(-2) +
+            ":" +
+            ("0" + updatedDate.getMinutes()).slice(-2);
+          const postData: PostData = {
+            id: snapshot.id,
+            uid: snapshot.data().uid,
+            displayName: snapshot.data().displayName,
+            avatarURL: snapshot.data().avatarURL,
+            imageURL: snapshot.data().imageURL,
+            caption: snapshot.data().caption,
+            updatedAt: updatedAt,
+            updatedTime: updatedTime,
+          };
+          return postData;
+        }
+      );
+      const sortedPosts = updatedPosts.sort(
+        (firstEl: PostData, secondEl: PostData) => {
+          return secondEl.updatedTime - firstEl.updatedTime;
+        }
+      );
+      setPosts(sortedPosts);
+    });
+  };
+
   useEffect(() => {
-    const unsubscribe: () => void = () => {
-      onSnapshot(postsQuery, (snapshots: QuerySnapshot<DocumentData>) => {
-        let updatedPosts: PostData[] = [];
-        snapshots.forEach(
-          async (snapshot: QueryDocumentSnapshot<DocumentData>) => {
-            const updatedTime = await snapshot.data().updatedAt.seconds;
-            const updatedDate = await snapshot.data().updatedAt.toDate();
-            const updatedAt =
-              updatedDate.getFullYear() +
-              "年" +
-              ("0" + updatedDate.getMonth()).slice(-2) +
-              "月" +
-              ("0" + updatedDate.getDate()).slice(-2) +
-              "日" +
-              " " +
-              ("0" + updatedDate.getHours()).slice(-2) +
-              ":" +
-              ("0" + updatedDate.getMinutes()).slice(-2);
-            const postData: PostData = {
-              id: snapshot.id,
-              uid: snapshot.data().uid,
-              displayName: snapshot.data().displayName,
-              avatarURL: snapshot.data().avatarURL,
-              imageURL: snapshot.data().imageURL,
-              caption: snapshot.data().caption,
-              updatedAt: updatedAt,
-              updatedTime: updatedTime,
-            };
-            updatedPosts.push(postData);
-          }
-        );
-        let sortedPosts: PostData[] = updatedPosts.sort(
-          (firstEl: PostData, secondEl: PostData) => {
-            return secondEl.updatedTime - firstEl.updatedTime;
-          }
-        );
-        setPosts(sortedPosts);
-      });
-    };
     unsubscribe();
     return () => {
-      onSnapshot(postsQuery, () => {});
+      unsubscribe();
+      console.log("クリーンアップ関数が実行されました");
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Issue
#127 

## 変更した内容
**src/components/BusinessUser/BusinessUser.tsx**
- [x] propsでイベントハンドラではなく、関数を渡す形に変更
- [x] BusinessUserコンポーネントをメモ化
- [x] レンダリング時にコンソールに出力するよう設定

**src/components/Post/Post.tsx**
- [x] propsでイベントハンドラではなく、関数を渡す形に変更
- [x] propsの内容を分割代入
- [x] Postコンポーネントをメモ化
- [x] レンダリング時にコンソールに出力するよう設定

**src/components/MyPosts/MyPosts.tsx**
- [x] Postコンポーネントをメモ化
- [x] レンダリング時にコンソールに出力するよう設定

**src/components/Upload/Upload.tsx**
- [x] propsでイベントハンドラではなく、関数を渡す形に変更
- [x] Uploadコンポーネントをメモ化
- [x] レンダリング時にコンソールに出力するよう設定

**src/hooks/useFeeds.ts**
- [x] レンダリング時にコンソールに出力するよう設定

**src/components/Feed/Feed.tsx**
- [x] Feedコンポーネントをメモ化
- [x] 関数`closeUpload()`にuseCallbackを適用
- [x] 関数`closeProfile()`にuseCallbackを適用
- [x] 42行目の三項演算子の記述がわかりにくいので、if文を使った記述に変更



## 動作チェック

1. tsugumonにログイン
![スクリーンショット 2022-05-09 23 49 30（2）](https://user-images.githubusercontent.com/98272835/167436936-02814b19-0d57-41ab-ae70-da989aaeda5a.png)
- [x] useFeeds.tsとFeed .tsxがそれぞれ２回づつレンダリングされることを確認
- [x] onSnapshotが一度しか実行されていないことを確認

2.プロフィール表示ボタンをクリック
![スクリーンショット 2022-05-09 23 50 21（2）](https://user-images.githubusercontent.com/98272835/167437238-a568379c-8081-4fdf-a1b5-ca05de00dc6c.png)
- [x] usePostsのonSnapshotが一度しか実行されていないことを確認

3. 投稿ボタン➕をクリック
![スクリーンショット 2022-05-09 23 50 57（2）](https://user-images.githubusercontent.com/98272835/167437521-6639b452-8bba-4443-bf39-242d33fe6238.png)
- [x] BusinessUser.tsxが再レンダリングされないことを確認


 