### PR TITLE
✨ URLの遷移後に対象ユーザーのプロフィールを表示する機能を実装

### DIFF
--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -1,9 +1,66 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Params, useParams } from "react-router-dom";
+import { db } from "../firebase";
+import {
+  collection,
+  CollectionReference,
+  DocumentData,
+  getDocs,
+  Query,
+  query,
+  QueryDocumentSnapshot,
+  QuerySnapshot,
+  where,
+} from "firebase/firestore";
 
 const Profile: React.VFC = () => {
-  let params:Readonly<Params<string>>= useParams();
-  return <h2>{params.username}のプロフィール画面</h2>;
+  const params: Readonly<Params<string>> = useParams();
+  const [username, setUsername] = useState<string>("");
+  const [displayName, setDisplayName] = useState<string>("");
+  const [photoURL, setPhotoURL] = useState<string>("");
+  const [userType, setUserType] = useState<
+    "businessUser" | "normalUser" | null
+  >(null);
+
+  const setProfile = async (isMounted: boolean) => {
+    setUsername(params.username!);
+    const usersRef: CollectionReference<DocumentData> = collection(db, "users");
+    const userQuery: Query<DocumentData> = query(
+      usersRef,
+      where("username", "==", username)
+    );
+    const querySnapshot: QuerySnapshot<DocumentData> = await getDocs(userQuery);
+    querySnapshot.forEach((doc: QueryDocumentSnapshot) => {
+      if (isMounted) {
+        setDisplayName(doc.data().displayName);
+        setPhotoURL(doc.data().photoURL);
+        setUserType(doc.data().userType);
+        console.log(userType);
+      }
+    });
+  };
+
+  useEffect(() => {
+    let isMounted = true;
+    setProfile(isMounted);
+    return () => {
+      isMounted = false;
+    };
+  });
+
+  return (
+    <div>
+      <div id="top">
+        <img
+          id="avatar"
+          src={photoURL ? photoURL : `${process.env.PUBLIC_URL}/noAvatar.png`}
+          alt="アバター画像"
+        />
+        <p id="username">{username}</p>
+        <p id="displayName">{displayName}</p>
+      </div>
+    </div>
+  );
 };
 
 export default Profile;


### PR DESCRIPTION
## Issue
#138 

## 変更した内容
**src/routes/Profile.tsx**
- [x] URLパラメータからusernameを抽出するコードを追加
- [x] usernameをキーとして、usersコレクションからユーザーのプロフィール情報を抽出するコードを追加
- [x] 抽出したプロフィール情報を画面上に表示するコードを追加

## 動作チェック
1. tsugumonにログイン
2. Feedコンポーネントに表示されているアバター画像をクリック
3. URLが対象ユーザーのプロフィールページに遷移する
- [x] 対象ユーザーのアバター画像が表示されることを確認
- [x] 対象ユーザーのドメイン名が表示されることを確認
- [x] 対象ユーザーの会社名が表示されることを確認