### PR TITLE
👍 ユーザー登録画面に専用のURLを割り当てる

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "./app/hooks";
+import { Outlet } from "react-router-dom";
 import { selectUser, login, logout } from "./features/userSlice";
 import Basis from "./components/Basis/Basis";
 import UserAuthentication from "./components/UserAuthentication/UserAuthentication";
@@ -58,6 +59,11 @@ const App: React.FC = () => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
-  return <>{user.uid ? <Basis /> : <UserAuthentication />}</>;
+  return (
+    <>
+      {user.uid ? <Basis /> : <UserAuthentication />}
+      <Outlet />
+    </>
+  );
 };
 export default App;

--- a/src/components/UserAuthentication/UserAuthentication.tsx
+++ b/src/components/UserAuthentication/UserAuthentication.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import SignUp from "../SignUp/SignUp";
+import { Link } from "react-router-dom";
 import { auth } from "../../firebase";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { Lock, Visibility, VisibilityOff } from "@mui/icons-material";
@@ -8,7 +8,6 @@ const UserAuthentication = () => {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [showPassword, setShowPassword] = useState<boolean>(false);
-  const [signUp, setSignUp] = useState<boolean>(false);
 
   const login: (
     e: React.MouseEvent<HTMLInputElement, MouseEvent>
@@ -17,10 +16,6 @@ const UserAuthentication = () => {
     if (email && password) {
       signInWithEmailAndPassword(auth, email, password);
     }
-  };
-
-  const closeSignUp = () => {
-    setSignUp(false);
   };
 
   return (
@@ -87,18 +82,9 @@ const UserAuthentication = () => {
         </div>
         <div>
           <p>アカウントをお持ちではないですか？</p>
-          <button
-            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-              e.preventDefault();
-              setSignUp(true);
-              console.log(signUp);
-            }}
-          >
-            新規登録
-          </button>
+          <Link to="/signup">新規登録</Link>
         </div>
       </form>
-      {signUp && <SignUp backToLogin={closeSignUp} />}
     </div>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App";
+import SignUp from "./routes/SignUp";
 import Profile from "./routes/Profile";
 import { store } from "./app/store";
 import { Provider } from "react-redux";
@@ -13,8 +14,10 @@ ReactDOM.render(
     <Provider store={store}>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<App />}></Route>
-          <Route path=":username" element={<Profile />} />
+          <Route path="/" element={<App />}>
+            <Route path="/signup" element={<SignUp />} />
+            <Route path=":username" element={<Profile />} />
+          </Route>
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/routes/SignUp.tsx
+++ b/src/routes/SignUp.tsx
@@ -1,0 +1,292 @@
+import React, { useState } from "react";
+import { useAppDispatch } from "../app/hooks";
+import { useNavigate } from "react-router-dom";
+import { setUserProfile, toggleIsNewUser } from "../features/userSlice";
+import { auth, db, storage } from "../firebase";
+import {
+  createUserWithEmailAndPassword,
+  updateProfile,
+  User,
+  UserCredential,
+} from "firebase/auth";
+import {
+  doc,
+  DocumentData,
+  DocumentReference,
+  setDoc,
+  collection,
+  getDocs,
+  where,
+  query,
+  QuerySnapshot,
+  CollectionReference,
+  Query,
+} from "firebase/firestore";
+import {
+  getDownloadURL,
+  ref,
+  StorageReference,
+  uploadBytes,
+} from "firebase/storage";
+import { Visibility, VisibilityOff, AddAPhoto } from "@mui/icons-material";
+
+const SignUp: React.VFC = () => {
+  const types: string[] = ["image/png", "image/jpeg"];
+  const [displayName, setDisplayName] = useState<string>("");
+  const [username, setUsername] = useState<string>("");
+  const [usernamePattern, setUsernamePattern] = useState<boolean>(true);
+  const [duplicate, setDuplicate] = useState<boolean>(false);
+  const [avatarImage, setAvatarImage] = useState<ArrayBuffer | null>(null);
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [passwordPattern, setPasswordPattern] = useState<boolean>(true);
+  const [passwordLength, setPasswordLength] = useState<boolean>(false);
+  const [avatarPreview, setAvatarPreview] = useState<string>("");
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const onChangeAvatarImage: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => void = (event) => {
+    const file: File = event.target.files![0];
+    const reader: FileReader = new FileReader();
+    if (types.includes(file.type)) {
+      reader.addEventListener("load", () => {
+        const arrayBuffer: ArrayBuffer = reader.result as ArrayBuffer;
+        setAvatarImage(arrayBuffer);
+      });
+      // NOTE >> ブラウザがBlobURLSchemeをサポートしていない場合は処理を中断
+      if (!window.URL) return;
+      setAvatarPreview(window.URL.createObjectURL(file));
+      reader.readAsArrayBuffer(file);
+      event.target.value = "";
+    } else {
+      alert("拡張子が「png」もしくは「jpg」の画像ファイルを選択してください。");
+    }
+  };
+
+  const checkPassword: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => Promise<void> = async (event) => {
+    setPassword(event.target.value);
+    setPasswordPattern(true);
+    setPasswordLength(false);
+    const regex = /^[a-z|A-Z|0-9|_]+$/;
+    if (event.target.value.length > 0) {
+      setPasswordPattern(regex.test(event.target.value));
+    }
+    if (passwordPattern === false) {
+      setPassword("");
+    }
+    if (event.target.value.length < 8 || event.target.value.length > 20) {
+      setPassword("");
+      setPasswordLength(true);
+    }
+  };
+
+  const checkUsername: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => Promise<void> = async (event) => {
+    setUsername(`@${event.target.value}`);
+
+    setUsernamePattern(true);
+    const regex = /^[a-z|A-Z|0-9|_]+$/;
+    if (event.target.value.length > 0) {
+      setUsernamePattern(regex.test(event.target.value));
+    }
+
+    setDuplicate(false);
+    const usersRef: CollectionReference<DocumentData> = collection(db, "users");
+    const usersQuery: Query<DocumentData> = query(
+      usersRef,
+      where("username", "==", `@${event.target.value}`)
+    );
+    const usersSnap: QuerySnapshot<DocumentData> = await getDocs(usersQuery);
+    usersSnap.forEach(() => {
+      setDuplicate(true);
+      setUsername("");
+    });
+  };
+
+  const signUp: (
+    event: React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => Promise<void> = async (event) => {
+    event.preventDefault();
+    let url: string = "";
+    await createUserWithEmailAndPassword(auth, email, password).then(
+      async (userCredential: UserCredential) => {
+        const user: User = userCredential.user;
+        const avatarRef: StorageReference = ref(storage, `avatars/${user.uid}`);
+        if (avatarImage) {
+          await uploadBytes(avatarRef, avatarImage);
+          url = await getDownloadURL(avatarRef);
+        }
+        await updateProfile(user, {
+          displayName: displayName,
+          photoURL: url,
+        });
+        const userRef: DocumentReference<DocumentData> = doc(
+          db,
+          `users/${user.uid}`
+        );
+        setDoc(userRef, {
+          displayName: displayName,
+          username: username,
+          photoURL: url,
+          userType: null,
+          followerCount: 0,
+        });
+      }
+    );
+    navigate("/", { replace: true });
+    dispatch(
+      setUserProfile({
+        displayName: displayName,
+        username: username,
+        avatarURL: url,
+      })
+    );
+    dispatch(toggleIsNewUser(true));
+  };
+
+  return (
+    <div>
+      <p>ユーザー登録</p>
+      <form name="form">
+        <div>
+          <label htmlFor="displayName">会社名・個人名</label>
+          <input
+            name="textbox"
+            type="text"
+            id="displayName"
+            value={displayName}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setDisplayName(event.target.value);
+            }}
+            autoFocus
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            name="textbox"
+            type="email"
+            id="email"
+            value={email}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setEmail(event.target.value);
+            }}
+            placeholder="例) tsugumon@examle.com"
+            required
+          />
+        </div>
+        <div>
+          <div>
+            <img
+              id="avatar"
+              src={
+                avatarPreview
+                  ? avatarPreview
+                  : `${process.env.PUBLIC_URL}/noAvatar.png`
+              }
+              alt="ユーザーのアバター画像"
+            />
+            <label htmlFor="selectAvatarImage">
+              <AddAPhoto />
+            </label>
+            <input
+              type="file"
+              id="selectAvatarImage"
+              accept="image/png,image/jpeg"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                onChangeAvatarImage(event);
+              }}
+            />
+          </div>
+          <div>
+            <button
+              id="clearAvatarImage"
+              onClick={() => {
+                setAvatarImage(null);
+                setAvatarPreview("");
+              }}
+            >
+              画像を消す
+            </button>
+          </div>
+        </div>
+        <div>
+          <label htmlFor="password">パスワード</label>
+          <p>パスワードは8文字以上20文字以下の文字を入力してください。</p>
+          <p>
+            入力できる文字はアルファベットの大文字、小文字、数字、_(アンダーバー)の4種類です。
+          </p>
+          <input
+            name="textbox"
+            type={showPassword ? "text" : "password"}
+            id="password"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              checkPassword(event);
+            }}
+          />
+          <div
+            onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+              event.preventDefault();
+              setShowPassword(!showPassword);
+            }}
+          >
+            {showPassword ? <Visibility /> : <VisibilityOff />}
+          </div>
+          <p>
+            {passwordPattern === false && "入力できない文字が含まれいます。"}
+          </p>
+          <p>{passwordLength && "8文字以上20文字以下で入力してください。"}</p>
+        </div>
+        <div>
+          <label>ユーザー名を入力</label>
+          <p>
+            入力できる文字はアルファベットの大文字、小文字、数字、_(アンダーバー)の4種類です。
+          </p>
+          <input
+            type="text"
+            id="username"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              checkUsername(event);
+            }}
+          />
+          <p>{duplicate && "既に使用されているユーザー名です。"}</p>
+          <p>
+            {usernamePattern === false && "入力できない文字が含まれいます。"}
+          </p>
+        </div>
+        <div>
+          <input
+            type="submit"
+            value="登録する"
+            onClick={(
+              event: React.MouseEvent<HTMLInputElement, MouseEvent>
+            ) => {
+              signUp(event);
+            }}
+            disabled={!displayName || !email || !username || !password}
+          />
+        </div>
+        <div>
+          <button
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.preventDefault();
+              navigate(-1);
+            }}
+          >
+            ログイン画面に戻る
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default SignUp;


### PR DESCRIPTION
## Issue
#143 

## 変更した内容

**src/components/UserAuthentication/UserAuthentication.tsx**
- [x]  UserAuthenticationに`<Link />`を追加　※不要になるpropsは削除
- [x]  `<UserAuthentication/>`から不要になった<SignUp/>に関する記述を削除

**src/index.tsx**
- [x] index.tsxに`<SignUp />`へのルートを追記

**src/routes/SignUp.tsx**
- [x] 履歴を移動できるよう、useNavigateを追加インポート
- [x] Firebaseへのアカウント登録が完了したら、/signupから/に戻る処理を追記


## 動作の確認
1. tsugumonのログインページの「新規登録」ボタンをクリック
2.新規登録画面に遷移する
- [x] URLが`http://localhost:3000/signup`となっていることを確認
3. 「ログイン画面に戻る」ボタンをクリック
4.ログイン画面に遷移する
- [x] URLが`http://localhost:3000/`となっていることを確認
5. 入力フォームに必要項目を入力し、「登録」ボタンをクリック
6. ユーザータイプの選択画面が表示される
- [x] URLが`http://localhost:3000/`となっていることを確認
7. ユーザータイプを選択し、「この内容で登録する」をクリック
8. Feed画面が表示される
9. FirebaseのAuthenticationのコンソールを開く
- [x] 先ほど登録したユーザーの情報が記録されているか確認
11. FirebaseのFirestoreのコンソールを開く
- [x] 先ほど要録したユーザーの情報が記録されているか確認
