### PR TITLE
👍 デモユーザーの登録情報に新たなサブコレクションを追加

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -9,9 +9,6 @@
       "userType": "business",
       "introduction": "八代平野でトマトのハウス栽培を営んでいます。家族経営で、まだまだ小さい規模ですが、甘くてフルーティーなトマトが自慢です！",
       "background": "backgrounds/@tsugumonBackground.jpg",
-      "owner": "継田 譲司",
-      "address": "熊本県八代市本町○○番地",
-      "typeOfWork": "農家",
       "posts": [
         {
           "username": "@tsugumon",
@@ -19,7 +16,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/01_tanemomi.jpg",
           "caption": "来年も質のいい米を作るため、厳選して種籾を採取しました🍀稲の伝染病を防ぐため、JAから購入した種籾も混ぜて、次の一年に備えます❗️",
-          "updatedDate": "2021,11,1,16:20"
+          "timestamp": "2021,11,1,16:20"
         },
         {
           "username": "@tsugumon",
@@ -27,7 +24,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/02_tanemomi2.jpg",
           "caption": "種籾のアップ📷けっして籾を傷めないように、注意して脱穀します",
-          "updatedDate": "2021,11,1,16:21"
+          "timestamp": "2021,11,1,16:21"
         },
         {
           "username": "@tsugumon",
@@ -35,7 +32,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/03_tokotuchi.jpg",
           "caption": "だんだん春の気配がしてきましたね🍀今日は苗を育てるために床土を作りました！床土は同じ性質の土が大量に必要になるので、用意するのが大変です💦ちなみに床土は籾殻の燃え滓や肥料を混ぜて作ります😉",
-          "updatedDate": "2022,4,1, 15:30"
+          "timestamp": "2022,4,1, 15:30"
         },
         {
           "username": "@tsugumon",
@@ -43,7 +40,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/04_azenuri.jpg",
           "caption": "田んぼの畦塗りをしました！畦に割れ目や穴があると水漏れの原因になるので、必須の作業です。トラクタを使って、均質に畦をならします。",
-          "updatedDate": "2022,4,15, 15:30"
+          "timestamp": "2022,4,15, 15:30"
         },
         {
           "username": "@tsugumon",
@@ -51,7 +48,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/05_taokoshi.jpg",
           "caption": "トラクタを使って田起こしします。田起こしは、なるべく乾燥するように田んぼの土を耕す作業です。肥料や稲の切り株、刈草なんかもすき込みます🍀",
-          "updatedDate": "2022,4,16, 15:30"
+          "timestamp": "2022,4,16, 15:30"
         },
         {
           "username": "@tsugumon",
@@ -59,7 +56,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/06_taokoshi2.jpg",
           "caption": "田起こし完了✨田起こしでは、深く耕すことも大切ですが、耕す深さが平均していることも大切です。",
-          "updatedDate": "2022,4,16, 15:30"
+          "timestamp": "2022,4,16, 15:30"
         },
         {
           "username": "@tsugumon",
@@ -67,7 +64,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/07_ensuisen.jpg",
           "caption": "塩水選実施中❗️塩水選は種籾を塩水に浸して良い籾を選別する作業です✨塩水は真水よりモノが浮きやすくなりますが、中身のしっかり詰まった良い籾は沈んだままになります。浮き上がってきた悪い籾だけザルで掬って捨てます。",
-          "updatedDate": "2022,4,18, 15:30"
+          "timestamp": "2022,4,18, 15:30"
         },
         {
           "username": "@tsugumon",
@@ -75,7 +72,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/08_hasyu.jpg",
           "caption": "これは播種機といって、床土を入れた育苗箱にタネを撒く機会です✨いよいよ種まきです❗️",
-          "updatedDate": "2022,4,19, 9:00"
+          "timestamp": "2022,4,19, 9:00"
         },
         {
           "username": "@tsugumon",
@@ -83,7 +80,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/09_naeshiro.jpg",
           "caption": "種まきが完了した育苗箱を苗代田に設置しました。次はビニールトンネルで被覆するため、鉄線で骨組みを作っていきます❗️",
-          "updatedDate": "2022,4,19, 11:00"
+          "timestamp": "2022,4,19, 11:00"
         },
         {
           "username": "@tsugumon",
@@ -91,9 +88,15 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FWk6hsfRGwPPbwWM2GTz3MqWHUFG2?alt=media&token=93025331-5879-49f7-9236-8ea723fc22bb",
           "image": "posts/@tsugumon/10_naeshiro2.jpg",
           "caption": "幼い苗を保温するため、ビニールトンネルを設置しました❗️鉄線を使ってアーチ常の骨組みを作り、ビニールシートで覆いました。２週間後にはまたシートを取り外す作業が待っています😅",
-          "updatedDate": "2022,4,20, 11:00"
+          "timestamp": "2022,4,20, 11:00"
         }
-      ]
+      ],
+      "option": "business",
+      "business": {
+        "address": "熊本県八代市本町○○番地",
+        "owner": "継田 譲司",
+        "typeOfWork": "農家"
+      }
     },
     {
       "email": "hiiragi_farm@gmail.com",
@@ -104,9 +107,6 @@
       "userType": "business",
       "introduction": "ひいらぎ農園は熊本県のほぼ中央に広がる八代平野に位置します。「農業の自立」を目指し、1994年(平成6年）にそれまでの家族経営から脱し、法人化しました。以来、水稲を中心に規模拡大を進め、現在米・小麦・ミニトマト・ブロッコリーの生産を行っています。併せてライスセンターを運営し、地域の皆さんの委託を受けて田畑の管理、耕作から収穫までの諸作業を個々のニーズに応じて行っております。！",
       "background": "backgrounds/@hiiragi_farmBackground.jpg",
-      "owner": "柊 道夫",
-      "address": "熊本県八代市新浜町○○番地",
-      "typeOfWork": "農家",
       "posts": [
         {
           "username": "@hiiragi_farm",
@@ -114,7 +114,7 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FynZK9h51OAgVnEXx4dHE93wwpj13?alt=media&token=00189094-ed98-47f0-9a6b-f0a3cafedcb9",
           "image": "posts/@hiiragi_farm/01_shirokaki.jpg",
           "caption": "水が入った田んぼを代かきしています。トラクターから見える景色はこんな感じ👨‍🌾サイドミラーには鴨が写ってますね〜🦆",
-          "updatedDate": "2022,6,10, 9:00"
+          "timestamp": "2022,6,10, 9:00"
         },
         {
           "username": "@hiiragi_farm",
@@ -122,9 +122,15 @@
           "avatarURL": "https://firebasestorage.googleapis.com/v0/b/tsugumon-a83a1.appspot.com/o/avatars%2FynZK9h51OAgVnEXx4dHE93wwpj13?alt=media&token=00189094-ed98-47f0-9a6b-f0a3cafedcb9",
           "image": "posts/@hiiragi_farm/02_taue.jpg",
           "caption": "私が抱えているのが米の苗です🌱苗代で大事に育てた苗をこれから田んぼに植えていきます❗️",
-          "updatedDate": "2022,6,25, 9:00"
+          "timestamp": "2022,6,25, 9:00"
         }
-      ]
+      ],
+      "option": "business",
+      "business": {
+        "address": "熊本県八代市新浜町○○番地",
+        "owner": "柊 道夫",
+        "typeOfWork": "農家"
+      }
     }
   ]
 }

--- a/src/hooks/useDemo.ts
+++ b/src/hooks/useDemo.ts
@@ -28,9 +28,6 @@ interface FetchedUser {
   userType: string;
   introduction: string;
   background: string;
-  owner: string;
-  address: string;
-  typeOfWork: string;
   posts: [
     {
       uid: string;
@@ -39,9 +36,19 @@ interface FetchedUser {
       avatarURL: string;
       image: string;
       caption: string;
-      updatedDate: string;
+      timestamp: string;
     }
   ];
+  option: "business" | "normal";
+  business?: {
+    address: string;
+    owner: string;
+    typeOfWork: string;
+  };
+  normal?: {
+    birthdate: Date;
+    skill: string;
+  };
 }
 
 interface Post {
@@ -51,7 +58,7 @@ interface Post {
   avatarURL: string;
   imageURL: string;
   caption: string;
-  updatedAt: Date;
+  timestamp: Date;
 }
 
 const getUniqueName: () => string = () => {
@@ -116,16 +123,32 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
                     `users/${uid}`
                   );
                   setDoc(userRef, {
-                    displayName: user.displayName,
-                    username: userData.username,
-                    userType: userData.userType,
-                    introduction: userData.introduction,
                     backgroundURL: backgroundURL,
-                    owner: userData.owner,
-                    address: userData.address,
-                    typeOfWork: userData.typeOfWork,
+                    displayName: user.displayName,
+                    introduction: userData.introduction,
+                    userType: userData.userType,
+                    username: userData.username,
                   });
-                  return userRef;
+                  if (userData.option === "business") {
+                    const optionRef: DocumentReference<DocumentData> = doc(
+                      db,
+                      `users/${uid}/option/business`
+                    );
+                    setDoc(optionRef, {
+                      address: userData.business!.address,
+                      owner: userData.business!.owner,
+                      typeOfWork: userData.business!.typeOfWork,
+                    });
+                  } else {
+                    const optionRef: DocumentReference<DocumentData> = doc(
+                      db,
+                      `users/${uid}/option/normal`
+                    );
+                    setDoc(optionRef, {
+                      birthdate: userData.normal!.birthdate,
+                      skill: userData.normal!.skill,
+                    });
+                  }
                 })
                 .then(async () => {
                   const postsData = userData.posts;
@@ -150,7 +173,7 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
                         avatarURL: postData.avatarURL,
                         imageURL: url,
                         caption: postData.caption,
-                        updatedAt: new Date(postData.updatedDate),
+                        timestamp: new Date(postData.timestamp),
                       };
                       await setDoc(postRef, post);
                       setProgress("done");


### PR DESCRIPTION
## Issue
#151 

## 変更した内容
**public/data.json**
- [x] `updateDate`のキー名称を`timestamp`に変更
- [x] 新たなキーとして`option`を追加
- [x] 新たなキーとして`business`を追加

**src/hooks/useDemo.ts**
- [x] fetchしたユーザーデータの要素のうち`option`キーが`business`だったら、サブコレクション`option`を作成し、`business`というドキュメント名で`address`と`owner`と`typeOfWork`の値をFIrestoreに登録するよう、コードを修正


## 動作の確認

1. ログイン画面で「ユーザー情報の登録」ボタンをクリック
2. ユーザー選択画面に変遷する
3. Firebaseのコンソールを開く
- [x] Authenticationに２人分のユーザーアカウントが登録されていることを確認
- [x] Storageに`avatar`、`background`、`posts`の３つのフォルダが作成されていることを確認
- [x] Firestoreの`users`コレクションのドキュメントの中にサブコレクション`option`が作成されていることを確認
- [x] Firestoreの`users`コレクションのドキュメントの中にサブコレクション`posts`が作成されていることを確認