### PR TITLE
✨ React Routerでプロフィール画面を表示する機能を実装

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -91,7 +91,6 @@
           "timestamp": "2022,4,20, 11:00"
         }
       ],
-      "option": "business",
       "business": {
         "address": "熊本県八代市本町○○番地",
         "owner": "継田 譲司",
@@ -125,7 +124,6 @@
           "timestamp": "2022,6,25, 9:00"
         }
       ],
-      "option": "business",
       "business": {
         "address": "熊本県八代市新浜町○○番地",
         "owner": "柊 道夫",

--- a/src/hooks/useDemo.ts
+++ b/src/hooks/useDemo.ts
@@ -79,7 +79,6 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
   uploadDemo
 ) => {
   const [progress, setProgress] = useState<"wait" | "run" | "done">("wait");
-
   const registData: () => void = async () => {
     setProgress("run");
     const response: Response = await fetch("data.json");
@@ -123,30 +122,31 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
                     `users/${uid}`
                   );
                   setDoc(userRef, {
+                    avatarURL: avatarURL,
                     backgroundURL: backgroundURL,
                     displayName: user.displayName,
                     introduction: userData.introduction,
                     userType: userData.userType,
                     username: userData.username,
                   });
-                  if (userData.option === "business") {
-                    const optionRef: DocumentReference<DocumentData> = doc(
-                      db,
-                      `users/${uid}/option/business`
-                    );
+                  const optionRef: DocumentReference<DocumentData> = doc(
+                    db,
+                    `option/${uid}/`
+                  );
+                  if (userData.userType === "business") {
                     setDoc(optionRef, {
                       address: userData.business!.address,
                       owner: userData.business!.owner,
                       typeOfWork: userData.business!.typeOfWork,
+                      username: userData.username,
+                      userType: userData.userType,
                     });
                   } else {
-                    const optionRef: DocumentReference<DocumentData> = doc(
-                      db,
-                      `users/${uid}/option/normal`
-                    );
                     setDoc(optionRef, {
                       birthdate: userData.normal!.birthdate,
                       skill: userData.normal!.skill,
+                      username: userData.username,
+                      userType: userData.userType,
                     });
                   }
                 })
@@ -164,7 +164,7 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
                       const url: string = await getDownloadURL(imageRef);
                       const postRef: DocumentReference<DocumentData> = doc(
                         db,
-                        `users/${uid}/posts/${getUniqueName()}`
+                        `posts/${getUniqueName()}`
                       );
                       const post: Post = {
                         uid: uid,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ ReactDOM.render(
           <Route path="/" element={<App />}>
             <Route path="home" element={<Home />} />
             <Route path="search" element={<p>Search</p>} />
-            <Route path="notification" element={<p>Notification</p>} />
+            <Route path="notifications" element={<p>Notifications</p>} />
             <Route path="email" element={<p>Email</p>} />
             <Route path="upload" element={<Upload />} />
             <Route path="signup" element={<SignUp />} />

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, memo } from "react";
 import { Params, useParams } from "react-router-dom";
 import { db } from "../firebase";
 import {
@@ -13,11 +13,19 @@ import {
   where,
 } from "firebase/firestore";
 
-const Profile: React.VFC = () => {
+const Profile: React.VFC = memo(() => {
   const params: Readonly<Params<string>> = useParams();
-  const [username, setUsername] = useState<string>("");
+  const [address, setAddress] = useState<string>("");
+  const [avatarURL, setAvatarURL] = useState<string>("");
+  const [backgroundURL, setBackgroundURL] = useState<string>("");
+  const [birthdate, setBirthdate] = useState<Date | null>(null);
+  const [skill, setSkill] = useState<string>("");
   const [displayName, setDisplayName] = useState<string>("");
-  const [photoURL, setPhotoURL] = useState<string>("");
+  const [introduction, setIntroduction] = useState<string>("");
+  const [owner, setOwner] = useState<string>("");
+  const [typeOfWork, setTypeOfWork] = useState<string>("");
+  const [username, setUsername] = useState<string>("");
+  const [userType, setUserType] = useState<"business" | "nurmal" | null>(null);
 
   const setProfile = async (isMounted: boolean) => {
     setUsername(params.username!);
@@ -26,13 +34,51 @@ const Profile: React.VFC = () => {
       usersRef,
       where("username", "==", username)
     );
-    const usersSnapshot: QuerySnapshot<DocumentData> = await getDocs(userQuery);
-    usersSnapshot.forEach((doc: QueryDocumentSnapshot) => {
-      if (isMounted) {
-        setDisplayName(doc.data().displayName);
-        setPhotoURL(doc.data().photoURL);
+    await getDocs(userQuery).then(
+      async (querySnapshot: QuerySnapshot<DocumentData>) => {
+        querySnapshot.forEach(
+          (userSnapshot: QueryDocumentSnapshot<DocumentData>) => {
+            if (!isMounted) {
+              return;
+            }
+            setAvatarURL(userSnapshot.data().avatarURL);
+            setBackgroundURL(userSnapshot.data().backgroundURL);
+            setDisplayName(userSnapshot.data().displayName);
+            setIntroduction(userSnapshot.data().introduction);
+          }
+        );
       }
-    });
+    );
+
+    const optionRef: CollectionReference<DocumentData> = collection(
+      db,
+      "option"
+    );
+    const optionQuery: Query<DocumentData> = query(
+      optionRef,
+      where("username", "==", username)
+    );
+    await getDocs(optionQuery).then(
+      async (querySnapshot: QuerySnapshot<DocumentData>) => {
+        querySnapshot.forEach(
+          (optionSnapshot: QueryDocumentSnapshot<DocumentData>) => {
+            if (!isMounted) {
+              return;
+            }
+            if (optionSnapshot.data().userType === "business") {
+              setAddress(optionSnapshot.data()!.address);
+              setOwner(optionSnapshot.data()!.owner);
+              setTypeOfWork(optionSnapshot.data()!.typeOfWork);
+              setUserType(optionSnapshot.data()!.userType);
+            } else {
+              setBirthdate(optionSnapshot.data()!.birthdate);
+              setSkill(optionSnapshot.data()!.skill);
+              setUserType(optionSnapshot.data()!.userType);
+            }
+          }
+        );
+      }
+    );
   };
 
   useEffect(() => {
@@ -46,16 +92,64 @@ const Profile: React.VFC = () => {
   return (
     <div>
       <div id="top">
+        <button
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+            window.history.back();
+          }}
+        >
+          戻る
+        </button>
+        <img id="background" src={backgroundURL} alt="背景画像" />
         <img
           id="avatar"
-          src={photoURL ? photoURL : `${process.env.PUBLIC_URL}/noAvatar.png`}
+          src={avatarURL ? avatarURL : `${process.env.PUBLIC_URL}/noAvatar.png`}
           alt="アバター画像"
         />
         <p id="username">{username}</p>
         <p id="displayName">{displayName}</p>
       </div>
+      <div id="profile">
+        <p>紹介文</p>
+        <p>{introduction}</p>
+        <button>さらに表示</button>
+        <div id="followerCount">
+          <p>フォロワー</p>
+          <p>０人</p>
+        </div>
+        <div id="followeeCount">
+          <p>フォロー中</p>
+          <p>０人</p>
+        </div>
+        {userType === "business" ? (
+          <div id="business">
+            <div id="owner">
+              <p>事業主</p>
+              <p>{owner}</p>
+            </div>
+            <div id="typeOfWork">
+              <p>職種</p>
+              <p>{typeOfWork}</p>
+            </div>
+            <div id="address">
+              <p>住所</p>
+              <p>{address}</p>
+            </div>
+          </div>
+        ) : (
+          <div id="normal">
+            <div id="birthdate">
+              <p>生年月日</p>
+              <p>{birthdate}</p>
+            </div>
+            <div id="skill">
+              <p>{skill}</p>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
-};
+});
 
 export default Profile;


### PR DESCRIPTION
## Issue
#158 

## 変更した内容
**public/data.json**
- [x] Firestoreに**option**コレクションを作る必要がなくなったため、キー「option」を削除

**Firestoreのデータ構成について**
- [x] usersコレクション > uidドキュメント > optionサブコレクション > businessドキュメントという構成からoptionコレクション > uidドキュメント といいう構成に変更。URLパラメーター「@username」を通してアクセスできるようにする
- [x] optionコレクションのuidドキュメントには、businessとnormalの両方のユーザータイプがアクセスできるようにする
- [x] ユーザータイプがbusinessの場合は、owner,typeOfWork,addressなどの情報を、normalの場合にはbirthdateとskillを入力できるようにする

**src/index.tsx**
- [x] Routeのパス指定が間違っていたので、ついでに修正

**src/routes/Profile.tsx**
- [x] `<BusinessUser />`で表示されていた情報と同じ情報を、URLパラメーターをヒントに取得し、表示するよう変更した


## 動作の確認
1. tsugumonにログイン
2. ホーム画面に移動
3. 「プロフィールを表示する」をクリック
- [x] プロフィールが適正に表示されることを確認
<img width="1440" alt="スクリーンショット 2022-06-19 22 58 03" src="https://user-images.githubusercontent.com/98272835/174484768-ca37cc82-4eef-4790-bb94-22eb47790c98.png">

