### PR TITLE
🐛 プロフィール表示画面が表示されない問題を解決

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,10 +23,8 @@ ReactDOM.render(
             <Route path="email" element={<p>Email</p>} />
             <Route path="upload" element={<Upload />} />
             <Route path="signup" element={<SignUp />} />
-            <Route path="users">
-              <Route path=":username" element={<Profile />} />
-            </Route>
           </Route>
+          <Route path="/:username" element={<Profile />} />
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -43,7 +43,7 @@ const Feed = memo(() => {
             />
           );
         })}
-        <Link to={`/users/${user.username}`}>
+        <Link to={`/${user.username}`}>
           <p>プロフィールを表示する</p>
         </Link>
         <Link to="/upload">


### PR DESCRIPTION
## Issue
#162 

## 変更した内容
src/index.tsx
- [x] ユーザーのプロフィール表示画面のルート指定を変更
- [x] 今まで`localhost:3000/users/${username}`のURLでプロフィール表示画面のルートを指定していたが、`localhost:3000/${username}` のURLへと指定を変更した

## 動作の確認
ホーム画面で「プロフィールを表示する」ボタンをクリックしたところ、問題なく対象の画面が表示されることを確認した。
![スクリーンショット 2022-06-21 2 53 47（2）](https://user-images.githubusercontent.com/98272835/174656132-137b4d4e-1dd0-4bf7-ad5c-921fe3e3d99f.png)
