### PR TITLE
✨ ログインユーザーのプロフィール編集機能を再実装する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "./app/hooks";
-import { Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 import { selectUser, login, logout } from "./features/userSlice";
-import { Link } from "react-router-dom";
 import UserAuthentication from "./components/UserAuthentication/UserAuthentication";
 import { auth, db } from "./firebase";
 import { onAuthStateChanged, Unsubscribe, User } from "firebase/auth";
@@ -24,7 +23,7 @@ const App: React.FC = () => {
       auth,
       async (authUser: User | null) => {
         if (authUser) {
-          let userType: "businessUser" | "normalUser" | null = null;
+          let userType: "business" | "normal" | null = null;
           let username: string = "";
           const userRef: DocumentReference<DocumentData> = doc(
             db,

--- a/src/components/SelectUserType/SelectUserType.tsx
+++ b/src/components/SelectUserType/SelectUserType.tsx
@@ -9,16 +9,14 @@ const SelectUserType = () => {
   if (process.env.NODE_ENV === "development") {
     console.log("SelectUserTypeがレンダリングされました");
   }
-  const [userType, setUserType] = useState<
-    "businessUser" | "normalUser" | null
-  >(null);
+  const [userType, setUserType] = useState<"business" | "normal" | null>(null);
 
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
 
   const registUserType: (
     e: React.MouseEvent<HTMLInputElement, MouseEvent>,
-    userType: "businessUser" | "normalUser" | null
+    userType: "business" | "normal" | null
   ) => Promise<void> = async (e, userType) => {
     e.preventDefault();
     const userRef = doc(db, "users", user.uid);
@@ -46,7 +44,7 @@ const SelectUserType = () => {
             id="businessUser"
             data-testid="businessUser"
             onChange={() => {
-              setUserType("businessUser");
+              setUserType("business");
             }}
           />
         </div>
@@ -66,7 +64,7 @@ const SelectUserType = () => {
             id="normalUser"
             data-testid="normalUser"
             onChange={() => {
-              setUserType("normalUser");
+              setUserType("normal");
             }}
           />
         </div>

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -5,7 +5,7 @@ export interface User {
   uid: string;
   username: string;
   displayName: string;
-  userType: "businessUser" | "normalUser" | null;
+  userType: "business" | "normal" | null;
   avatarURL: string;
   isNewUser: boolean;
 }
@@ -18,7 +18,7 @@ export interface UserLogin {
   uid: string;
   username: string;
   displayName: string;
-  userType: "businessUser" | "normalUser" | null;
+  userType: "business" | "normal" | null;
   avatarURL: string;
 }
 
@@ -42,7 +42,7 @@ export const userSlice = createSlice({
       state.userType = action.payload.userType;
       state.avatarURL = action.payload.avatarURL;
     },
-    logout: (state:UserLogin) => {
+    logout: (state: UserLogin) => {
       state.uid = "";
       state.username = "";
       state.displayName = "";
@@ -56,7 +56,7 @@ export const userSlice = createSlice({
     },
     updateUserType: (
       state,
-      action: PayloadAction<"businessUser" | "normalUser" | null>
+      action: PayloadAction<"business" | "normal" | null>
     ) => {
       state.userType = action.payload;
     },

--- a/src/hooks/useDemo.ts
+++ b/src/hooks/useDemo.ts
@@ -46,7 +46,7 @@ interface FetchedUser {
     typeOfWork: string;
   };
   normal?: {
-    birthdate: Date;
+    birthdate: string;
     skill: string;
   };
 }
@@ -136,15 +136,20 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
                   if (userData.userType === "business") {
                     setDoc(optionRef, {
                       address: userData.business!.address,
+                      birthdate: "",
                       owner: userData.business!.owner,
+                      skill: "",
                       typeOfWork: userData.business!.typeOfWork,
                       username: userData.username,
                       userType: userData.userType,
                     });
                   } else {
                     setDoc(optionRef, {
+                      address: "",
                       birthdate: userData.normal!.birthdate,
+                      owner: "",
                       skill: userData.normal!.skill,
+                      typeOfWork: "",
                       username: userData.username,
                       userType: userData.userType,
                     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import Home from "./routes/Home";
 import SignUp from "./routes/SignUp";
 import Profile from "./routes/Profile";
+import Setting from "./routes/Setting";
 import { store } from "./app/store";
 import { Provider } from "react-redux";
 import * as serviceWorker from "./serviceWorker";
@@ -23,8 +24,9 @@ ReactDOM.render(
             <Route path="email" element={<p>Email</p>} />
             <Route path="upload" element={<Upload />} />
             <Route path="signup" element={<SignUp />} />
+            <Route path="setting" element={<Setting />} />
           </Route>
-          <Route path="/:username" element={<Profile />} />
+          <Route path=":username" element={<Profile />} />
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, memo } from "react";
-import { Params, useParams } from "react-router-dom";
+import { useAppSelector } from "../app/hooks";
+import { selectUser } from "../features/userSlice";
+import { Link, Outlet, Params, useParams } from "react-router-dom";
 import { db } from "../firebase";
 import {
   collection,
@@ -18,7 +20,7 @@ const Profile: React.VFC = memo(() => {
   const [address, setAddress] = useState<string>("");
   const [avatarURL, setAvatarURL] = useState<string>("");
   const [backgroundURL, setBackgroundURL] = useState<string>("");
-  const [birthdate, setBirthdate] = useState<Date | null>(null);
+  const [birthdate, setBirthdate] = useState<string>("");
   const [skill, setSkill] = useState<string>("");
   const [displayName, setDisplayName] = useState<string>("");
   const [introduction, setIntroduction] = useState<string>("");
@@ -26,6 +28,8 @@ const Profile: React.VFC = memo(() => {
   const [typeOfWork, setTypeOfWork] = useState<string>("");
   const [username, setUsername] = useState<string>("");
   const [userType, setUserType] = useState<"business" | "nurmal" | null>(null);
+
+  const user = useAppSelector(selectUser);
 
   const setProfile = async (isMounted: boolean) => {
     setUsername(params.username!);
@@ -106,7 +110,11 @@ const Profile: React.VFC = memo(() => {
           src={avatarURL ? avatarURL : `${process.env.PUBLIC_URL}/noAvatar.png`}
           alt="アバター画像"
         />
-        <p id="username">{username}</p>
+        {user.username === username && (
+          <Link to="/setting">
+            <p>プロフィールを編集する</p>
+          </Link>
+        )}
         <p id="displayName">{displayName}</p>
       </div>
       <div id="profile">
@@ -148,6 +156,7 @@ const Profile: React.VFC = memo(() => {
           </div>
         )}
       </div>
+      <Outlet />
     </div>
   );
 });

--- a/src/routes/Setting.tsx
+++ b/src/routes/Setting.tsx
@@ -1,0 +1,505 @@
+import React, { useState, useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "../app/hooks";
+import { selectUser, setUserProfile } from "../features/userSlice";
+import { auth, db, storage } from "../firebase";
+import { updateProfile } from "firebase/auth";
+import {
+  doc,
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  getDoc,
+  setDoc,
+} from "firebase/firestore";
+import {
+  deleteObject,
+  getDownloadURL,
+  ref,
+  StorageReference,
+  uploadString,
+} from "firebase/storage";
+
+const Setting: React.VFC = () => {
+  const [avatarImage, setAvatarImage] = useState<string>("");
+  const [avatarURL, setAvatarURL] = useState<string>("");
+  const [backgroundImage, setBackgroundImage] = useState<string>("");
+  const [backgroundURL, setBackgroundURL] = useState<string>("");
+  const [birthdate, setBirthdate] = useState<string>("");
+  const [deleteAvatar, setDeleteAvatar] = useState<boolean>(false);
+  const [deleteBackground, setDeleteBackground] = useState<boolean>(false);
+  const [displayName, setDisplayName] = useState<string>("");
+  const [introduction, setIntroduction] = useState<string>("");
+  const [skill, setSkill] = useState<string>("");
+  const [username, setUsername] = useState<string>("");
+  const [address, setAddress] = useState<string>("");
+  const [owner, setOwner] = useState<string>("");
+  const [typeOfWork, setTypeOfWork] = useState<string>("");
+
+  // TODO >> 広告文の表示の有無を記録するステート「advertiseRef」を実装する。
+  // const [advertiseRef, setAdvertiseRef] = useState<string>("");
+
+  const dispatch = useAppDispatch();
+  const user = useAppSelector(selectUser);
+  const avatarRef: StorageReference = ref(storage, `avatars/${user.uid}/`);
+  const backgroundRef: StorageReference = ref(
+    storage,
+    `backgrounds/${user.uid}`
+  );
+  const userRef: DocumentReference<DocumentData> = doc(
+    db,
+    "users",
+    `${user.uid}`
+  );
+  const optionRef: DocumentReference<DocumentData> = doc(
+    db,
+    "option",
+    `${user.uid}`
+  );
+
+  let userType: "business" | "normal" | null = null;
+  const getProfile = async () => {
+    await getDoc(userRef)
+      .then((userSnapshot: DocumentSnapshot<DocumentData>) => {
+        setAvatarURL(user.avatarURL);
+        setBackgroundURL(userSnapshot.data()!.backgroundURL);
+        setDisplayName(user.displayName);
+        setIntroduction(userSnapshot.data()!.introduction);
+        setUsername(user.username);
+        userType = user.userType;
+      })
+      .catch((error: any) => {
+        if (process.env.NODE_ENV === "development") {
+          console.log(`エラーが発生しました:${error}`);
+        }
+      });
+    await getDoc(optionRef)
+      .then((optionSnapshot: DocumentSnapshot<DocumentData>) => {
+        setAddress(optionSnapshot.data()!.address);
+        setBirthdate(optionSnapshot.data()!.birthdate);
+        setOwner(optionSnapshot.data()!.owner);
+        setSkill(optionSnapshot.data()!.skill);
+        setTypeOfWork(optionSnapshot.data()!.typeOfWork);
+      })
+      .catch((error: any) => {
+        if (process.env.NODE_ENV === "development") {
+          console.log(`エラーが発生しました:${error}`);
+        }
+      });
+  };
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "development") {
+      console.log("useEffectが実行されました");
+    }
+    getProfile();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onChangeImageHandler: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    imageFor: "avatar" | "background"
+  ) => void = async (event, imageFor) => {
+    event.preventDefault();
+    const file: File = event.target.files![0];
+    if (["image/png", "image/jpeg"].includes(file.type) === true) {
+      const reader: FileReader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        const imgElement: HTMLImageElement = document.createElement("img");
+        const original: string = reader.result as string;
+        imgElement.src = original;
+        imgElement!.onload = () => {
+          const canvas: HTMLCanvasElement = document.createElement("canvas");
+          const MAX_WIDTH: number = 640;
+          const IMG_WIDTH: number = imgElement.naturalWidth;
+          const IMG_HEIGHT: number = imgElement.naturalHeight;
+          const SCALING: number = MAX_WIDTH / IMG_WIDTH;
+          canvas.width = MAX_WIDTH;
+          canvas.height = IMG_HEIGHT * SCALING;
+          const context: CanvasRenderingContext2D = canvas.getContext("2d")!;
+          context.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
+          const compressed: string = context.canvas.toDataURL();
+          const result: string = [original, compressed].sort(
+            (a: string, b: string) => a.length - b.length
+          )[0];
+          if (imageFor === "avatar") {
+            setAvatarImage(result);
+          } else {
+            setBackgroundImage(result);
+          }
+        };
+      };
+      reader.onerror = () => {
+        if (process.env.NODE_ENV === "development") {
+          console.log(reader.error);
+        }
+      };
+    }
+  };
+
+  const uploadAvatar: () => Promise<void> = async () => {
+    if (avatarImage) {
+      await uploadString(avatarRef, avatarImage, "data_url");
+      await getDownloadURL(avatarRef).then((url: string) => {
+        setAvatarURL(url);
+        setDoc(userRef, { photoURL: url }, { merge: true });
+        updateProfile(auth.currentUser!, {
+          photoURL: url,
+        });
+        dispatch(
+          setUserProfile({
+            displayName: displayName,
+            username: username,
+            avatarURL: url,
+          })
+        );
+      });
+      setAvatarImage("");
+    } else {
+      return;
+    }
+  };
+
+  const uploadBackground: () => Promise<void> = async () => {
+    if (backgroundImage) {
+      await uploadString(backgroundRef, backgroundImage, "data_url");
+      await getDownloadURL(backgroundRef).then((url: string) => {
+        setBackgroundURL(url);
+        setDoc(userRef, { backgroundURL: url }, { merge: true });
+      });
+      setBackgroundImage("");
+    } else {
+      return;
+    }
+  };
+
+  const editProfile: (
+    event: React.FormEvent<HTMLFormElement>
+  ) => Promise<void> = async (event) => {
+    event.preventDefault();
+    await setDoc(
+      userRef,
+      {
+        avatarURL: avatarURL,
+        backgroundURL: backgroundURL,
+        displayNamevent: displayName,
+        introduction: introduction,
+        usernamevent: username,
+      },
+      { merge: true }
+    );
+    await setDoc(
+      optionRef,
+      {
+        owner: owner,
+        typeOfWork: typeOfWork,
+        address: address,
+      },
+      { merge: true }
+    );
+    dispatch(
+      setUserProfile({
+        displayName: displayName,
+        username: username,
+        avatarURL: avatarURL,
+      })
+    );
+  };
+
+  const deleteImage: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    imageFor: "avatar" | "background"
+  ) => void = (e, imageFor) => {
+    e.preventDefault();
+    const imageRef: StorageReference =
+      imageFor === "avatar" ? avatarRef : backgroundRef;
+    imageFor === "avatar"
+      ? setDoc(userRef, { photoURL: "" }, { merge: true })
+      : setDoc(userRef, { backgroundURL: "" }, { merge: true });
+    deleteObject(imageRef).then(() => {
+      if (process.env.NODE_ENV === "development") {
+        console.log(`${imageFor}画像を削除しました`);
+      }
+      imageFor === "avatar" ? setAvatarURL("") : setBackgroundURL("");
+      imageFor === "avatar" &&
+        dispatch(
+          setUserProfile({
+            displayName: displayName,
+            username: username,
+            avatarURL: "",
+          })
+        );
+      imageFor === "avatar"
+        ? setDeleteAvatar(false)
+        : setDeleteBackground(false);
+    });
+  };
+
+  return (
+    <div>
+      <header>
+        <button
+          id="cancel"
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+            window.history.back();
+          }}
+        >
+          キャンセルする
+        </button>
+        <p>編集画面</p>
+      </header>
+      <div id="backgroundSection">
+        <div>
+          <img
+            id="backgroundPreview"
+            data-testid="backgroundPreview"
+            src={backgroundURL}
+            alt="ユーザーの背景画像"
+          />
+          <input
+            type="file"
+            id="backgroundImage"
+            accept="image/png,image/jpeg"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              onChangeImageHandler(event, "background");
+            }}
+            disabled={!!deleteBackground}
+          />
+          <label htmlFor="backgroundImage">背景画像を選択</label>
+        </div>
+        {backgroundURL && (
+          <button
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              setDeleteBackground(true);
+            }}
+            disabled={!!backgroundImage}
+          >
+            削除する
+          </button>
+        )}
+        {backgroundImage && (
+          <div id="backgroundChangeModal">
+            <p>背景画像を登録しますか？</p>
+            <p>画像を変更した場合、元の画像は削除されます</p>
+            <button onClick={uploadBackground}>はい</button>
+            <button
+              onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                event.preventDefault();
+                setBackgroundImage("");
+              }}
+            >
+              いいえ
+            </button>
+          </div>
+        )}
+        {deleteBackground && (
+          <div id="backgroundDeleteModal">
+            <p>現在登録されている背景画像を消去します。よろしいですか？</p>
+            <button
+              onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+                deleteImage(event, "background")
+              }
+            >
+              はい
+            </button>
+            <button
+              onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                event.preventDefault();
+                setDeleteBackground(false);
+              }}
+            >
+              いいえ
+            </button>
+          </div>
+        )}
+      </div>
+      <div id="avatarSection">
+        <div>
+          <img
+            id="avatar"
+            data-testid="avatar"
+            src={
+              avatarURL ? avatarURL : `${process.env.PUBLIC_URL}/noAvatar.png`
+            }
+            alt="ユーザーのアバター画像"
+          />
+          <label htmlFor="selectAvatarImage" data-testid="labelForAvatar">
+            アバター画像を選択
+          </label>
+          <input
+            type="file"
+            id="selectAvatarImage"
+            data-testid="selectAvatarImage"
+            accept="image/png,image/jpeg"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              onChangeImageHandler(event, "avatar");
+            }}
+            disabled = {!!deleteAvatar}
+          />
+        </div>
+        {avatarURL && (
+          <button
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.preventDefault();
+              setDeleteAvatar(true);
+            }}
+            disabled = {!!avatarImage}
+          >
+            削除する
+          </button>
+        )}
+        {avatarImage && (
+          <div id="avatarChangeModal">
+            <p>アバター画像を登録しますか？</p>
+            <p>画像を変更した場合、元の画像は削除されます</p>
+            <button onClick={uploadAvatar}>はい</button>
+            <button
+              onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                event.preventDefault();
+                setAvatarImage("");
+              }}
+            >
+              いいえ
+            </button>
+          </div>
+        )}
+        {deleteAvatar && (
+          <div>
+            <p>現在登録されている画像を消去します。よろしいですか？</p>
+            <button
+              onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+                deleteImage(event, "avatar")
+              }
+            >
+              はい
+            </button>
+            <button
+              onClick={(event: React.MouseEvent) => {
+                setDeleteAvatar(false);
+              }}
+            >
+              いいえ
+            </button>
+          </div>
+        )}
+      </div>
+      <form name="form" onSubmit={editProfile}>
+        <div>
+          {" "}
+          <label htmlFor="username" data-testid="username">
+            ユーザー名
+          </label>
+          <input
+            name="textbox"
+            type="text"
+            id="username"
+            value={username}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setUsername(event.target.value);
+            }}
+            required
+          />
+          <label htmlFor="displayName" data-testid="displayName">
+            {userType === "business" ? "会社名" : "ユーザー名"}
+          </label>
+          <input
+            name="textbox"
+            type="text"
+            id="displayName"
+            value={displayName}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setDisplayName(event.target.value);
+            }}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="introduction" data-testid="introduction">
+            紹介文
+          </label>
+          <textarea
+            id="introduction"
+            value={introduction}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+              setIntroduction(event.target.value);
+            }}
+          />
+        </div>
+        {userType === "business" ? (
+          <div>
+            <div>
+              <label htmlFor="owner">事業主</label>
+              <input
+                name="textbox"
+                type="text"
+                id="owner"
+                value={owner}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setOwner(event.target.value);
+                }}
+              />
+            </div>
+            <div>
+              <label htmlFor="typeOfWork">職種</label>
+              <input
+                name="textbox"
+                type="text"
+                id="address"
+                value={typeOfWork}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setTypeOfWork(event.target.value);
+                }}
+              />
+            </div>
+            <div>
+              <label htmlFor="address">住所</label>
+              <input
+                name="textbox"
+                type="text"
+                id="address"
+                value={address}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setAddress(event.target.value);
+                }}
+              />
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div>
+              <label htmlFor="birthdate">生年月日</label>
+              <input
+                name="textbox"
+                type="date"
+                id="birthdate"
+                value={birthdate}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setBirthdate(event.target.value);
+                }}
+              />
+            </div>
+            <div>
+              <label htmlFor="skill">資格・実績</label>
+              <input
+                name="textbox"
+                type="text"
+                id="skill"
+                value={skill}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setSkill(event.target.value);
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        <div>
+          <input type="submit" data-testid="submitProfile" value="登録する" />
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default Setting;


### PR DESCRIPTION
## Issue
#164 

## 変更した内容
プロジェクト全般
- [x] userTypeの定義を`"businessUser"|"normalUser"`から`"business"|"normal"`に変更

**src/hooks/useDemo.ts**
- [x] userTypeが"business"でも"normal"でも対応できるように、登録するオブジェクトのプロパティを追加

**src/hooks/useDemo.ts**
- [x] Settingコンポーネントを追加インポート
- [x] `<Route path="setting" />`という新たなルートの追加

**src/routes/Profile.tsx**
- [x] ステート`birthdate`をDateオブジェクトからstringへと型を変更

## 動作の確認

1. tsugumonにログイン
2. 「ホーム」ボタンをクリック
3. 「プロフィールを表示する」ボタンをクリック
4. 「プロフィールを編集する」ボタンをクリック
**背景画像の編集機能のチェック**
5. 「背景画像を選択」箇所の「ファイルを選択」ボタンをクリック
6. ファイルを選択
![スクリーンショット 2022-06-25 11 55 41（2）](https://user-images.githubusercontent.com/98272835/175756562-13a9cd00-2648-4ec5-a669-9c325b9f8127.png)
- [x] 「背景画像を登録しますか？」という文章と「はい」「いいえ」ボタンが表示されるか確認
- [x] 「削除する」ボタンが動作しないことを確認
7. 「背景画像を登録しますか？」という文章が表示されたら、「はい」ボタンをクリック
![スクリーンショット 2022-06-25 11 55 57（2）](https://user-images.githubusercontent.com/98272835/175756573-0aa70181-e412-4e6b-957a-beccceaad85f.png)

- [x] 画面上の背景画像のプレビューが新しい画像に切り替わることを確認
8. Firebaseコンソールのstorageを確認
- [x] 先ほど登録された画像が登録されていることを確認
9. 「削除する」ボタンをクリック
- [x] 「現在登録されている背景画像を消去します。」という文章と「はい」「いいえ」ボタンが表示されることを確認
![スクリーンショット 2022-06-25 11 56 07（2）](https://user-images.githubusercontent.com/98272835/175756589-f866d979-1d75-4ad9-b2a4-e2c10098483e.png)
- [x] 「ファイルを選択」ボタンが動作しないことを確認
10. 「現在登録されている背景画像を消去します。」という文章が表示されたら、「はい」ボタンをクリック
- [x]  画面上の背景画像のプレビューが表示されなくなることを確認
11. Firebaseコンソールのstorageを確認
- [x] 先ほど登録された画像が消去されていることを確認

**アバター画像の編集機能のチェック**
背景画像の編集機能のチェックと同様の作業をアバター画像においても行います。