### PR TITLE
👍 登録する画像データの圧縮を行う処理を追加する

### DIFF
--- a/src/functions/ResizeImage.ts
+++ b/src/functions/ResizeImage.ts
@@ -1,0 +1,25 @@
+export const resizeImage = async (original: string) => {
+  const loaded: HTMLImageElement = await new Promise(
+    (
+      resolve: (value: HTMLImageElement | PromiseLike<HTMLImageElement>) => void
+    ) => {
+      const img: HTMLImageElement = new Image();
+      img.src = original;
+      img.onload = () => resolve(img);
+    }
+  );
+  const canvas: HTMLCanvasElement = document.createElement("canvas");
+  const MAX_WIDTH: number = 640;
+  const IMG_WIDTH: number = loaded.naturalWidth;
+  const IMG_HEIGHT: number = loaded.naturalHeight;
+  const SCALING: number = MAX_WIDTH / IMG_WIDTH;
+  canvas.width = MAX_WIDTH;
+  canvas.height = IMG_HEIGHT * SCALING;
+  const context: CanvasRenderingContext2D = canvas.getContext("2d")!;
+  context.drawImage(loaded, 0, 0, canvas.width, canvas.height);
+  const resized: string = context.canvas.toDataURL();
+  const result: string = [original, resized].sort(
+    (a: string, b: string) => a.length - b.length
+  )[0];
+  return result;
+};

--- a/src/hooks/useDemo.ts
+++ b/src/hooks/useDemo.ts
@@ -18,6 +18,7 @@ import {
   User,
   UserCredential,
 } from "firebase/auth";
+import { resizeImage } from "../functions/ResizeImage";
 
 interface FetchedUser {
   email: string;
@@ -107,7 +108,8 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
         const avatarBuffer: ArrayBuffer = await (
           await fetch(`${process.env.PUBLIC_URL}/${userData.avatar}`)
         ).arrayBuffer();
-        const avatarImage: string = arrayBufferToDataURL(avatarBuffer);
+        const avatarOrigin: string = arrayBufferToDataURL(avatarBuffer);
+        const avatarImage: string = await resizeImage(avatarOrigin);
         const backgroundRef: StorageReference = ref(
           storage,
           `backgrounds/${uid}`
@@ -115,7 +117,8 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
         const backgroundBuffer: ArrayBuffer = await (
           await fetch(`${process.env.PUBLIC_URL}/${userData.background}`)
         ).arrayBuffer();
-        const backgroundImage: string = arrayBufferToDataURL(backgroundBuffer);
+        const backgroundOrigin: string = arrayBufferToDataURL(backgroundBuffer);
+        const backgroundImage: string = await resizeImage(backgroundOrigin);
         await uploadString(avatarRef, avatarImage, "data_url")
           .then(async () => {
             await uploadString(backgroundRef, backgroundImage, "data_url");
@@ -174,7 +177,8 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
               const postBuffer: ArrayBuffer = await (
                 await fetch(`${process.env.PUBLIC_URL}/${postData.image}`)
               ).arrayBuffer();
-              const postImage: string = arrayBufferToDataURL(postBuffer);
+              const postOrigin: string = arrayBufferToDataURL(postBuffer);
+              const postImage: string = await resizeImage(postOrigin);
               uploadString(imageRef, postImage, "data_url").then(async () => {
                 const url: string = await getDownloadURL(imageRef);
                 const postRef: DocumentReference<DocumentData> = doc(

--- a/src/routes/Upload.tsx
+++ b/src/routes/Upload.tsx
@@ -3,13 +3,13 @@ import { useAppSelector } from "../app/hooks";
 import { selectUser, User } from "../features/userSlice";
 import { useBatch } from "../hooks/useBatch";
 import { AddPhotoAlternate, Cancel } from "@mui/icons-material";
+import { resizeImage } from "../functions/ResizeImage";
 
 const Upload: React.FC = memo(() => {
   const user: User = useAppSelector(selectUser);
   const displayName: string = user.displayName;
   const avatarURL: string = user.avatarURL;
   const [postImage, setPostImage] = useState<string>("");
-  const [postPreview, setPostPreview] = useState<string>("");
   const [caption, setCaption] = useState<string>("");
   const [upload, setUpload] = useState<boolean>(false);
   const [cancelModal, setCancelModal] = useState<boolean>(false);
@@ -27,8 +27,9 @@ const Upload: React.FC = memo(() => {
     if (["image/png", "image/jpeg"].includes(file.type) === true) {
       const reader: FileReader = new FileReader();
       reader.readAsDataURL(file);
-      reader.onload = () => {
-        setPostImage(reader.result as string);
+      reader.onload = async () => {
+        const processed: string = await resizeImage(reader.result as string);
+        setPostImage(processed);
       };
     } else {
       alert("拡張子が「png」もしくは「jpg」の画像ファイルを選択してください。");
@@ -41,7 +42,6 @@ const Upload: React.FC = memo(() => {
   ) => {
     event.preventDefault();
     setPostImage("");
-    setPostPreview("");
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Issue
#175 

## 変更した内容
src/functions/ResizeImage.ts
- [x] 画像のサイズ変更を行う関数`resizeImage()`を作成し、別ファイルへと分離した

src/hooks/useDemo.ts
- [x] `resizeImage()`をインポートし、アバター画像と背景画像、および投稿画像のサイズ変更をおこなうようにした

src/routes/Upload.tsx
- [x] `resizeImage()`をインポートし、投稿画像のサイズ変更をおこなうようにした

src/routes/Setting.tsx
- [x] `resizeImage()`をインポートし、アバター画像と背景画像のサイズ変更をおこなうようにした

## 動作の確認
1. デモ用データの登録を再度、実行する
- [x] プロフィールの表示画面にアバター画像、背景画像、投稿画像が正常に表示されることを確認
- [x] Firebase Storageのコンソールを確認し、登録されている画像のデータサイズが縮小されていることを確認

2. 画像の投稿をおこなう
- [x] プロフィールの表示画面に先ほどの投稿画像が正常に表示されることを確認
- [x] Firebase Storageのコンソールを確認し、登録されている画像のデータサイズが縮小されていることを確認