### PR TITLE
🐛 ログアウトした際のURLに関するバグを解決しました

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet,useNavigate,NavigateFunction } from "react-router-dom";
 import React from "react";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { selectUser, logout, toggleIsNewUser } from "../features/userSlice";
@@ -24,6 +24,7 @@ interface PostData {
 
 const Feed = memo(() => {
   const dispatch = useAppDispatch();
+  const navigate:NavigateFunction = useNavigate();
   const user = useAppSelector(selectUser);
   const feeds: PostData[] = useFeeds();
   if (user.userType) {
@@ -52,6 +53,7 @@ const Feed = memo(() => {
         <button
           onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
             event.preventDefault();
+            navigate("/");
             signOut(auth).catch((error: any) => {
               console.log(`エラーが発生しました\n${error.message}`);
             });


### PR DESCRIPTION
## Issue
#185 

## 変更した内容
- [x] `<Home />`コンポーネントのログアウトボタンのクリックイベントに`useNavigate()`を追加しました

## 動作の確認
1. 任意のアカウント名でログイン
<img width="1440" alt="スクリーンショット 2022-07-11 23 23 52" src="https://user-images.githubusercontent.com/98272835/178287901-43b9b098-7792-464a-ae0a-5db5bc22d50c.png">

2. 「logout」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-07-11 23 24 33" src="https://user-images.githubusercontent.com/98272835/178288193-b1d14245-62ca-413b-9332-ab04ec556e61.png">

3. アプリからログアウトします
<img width="1440" alt="スクリーンショット 2022-07-11 23 24 38" src="https://user-images.githubusercontent.com/98272835/178288316-a89ea2ae-359d-4c69-b400-7586df3df1c0.png">

 - [x] URLが`http://localhost:3000/`となっているか確認
 - [x] ログイン画面以外の不要な情報が表示されていないことを確認