### PR TITLE
✨ <Search/>にユーザー検索タグを追加し、検索結果の表示機能を実装 #194

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+import {
+  collection,
+  DocumentData,
+  getDocs,
+  query,
+  Query,
+  QueryDocumentSnapshot,
+  QuerySnapshot,
+  where,
+} from "firebase/firestore";
+import { db } from "../firebase";
+
+export const useSearch: (filter: string | null) => string[] = (filter) => {
+  const [usernames, setUsernames] = useState<string[]>([]);
+  let isMounted: boolean = true;
+  if (filter === null) {
+    isMounted = false;
+  }
+  const usersQuery: Query<DocumentData> = query(
+    collection(db, "users"),
+    where("cropsTags", "array-contains", filter)
+  );
+
+  const getUsername: () => void = async () => {
+    if (isMounted === false) {
+      setUsernames([]);
+    }
+    getDocs(usersQuery).then((userSnaps: QuerySnapshot<DocumentData>) => {
+      setUsernames(
+        userSnaps.docs.map((userSnap: QueryDocumentSnapshot<DocumentData>) => {
+          return userSnap.data().username;
+        })
+      );
+    });
+  };
+
+  useEffect(() => {
+    getUsername();
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      isMounted = false;
+    };
+  }, [filter]);
+
+  return usernames;
+};

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -13,10 +13,7 @@ import { db } from "../firebase";
 
 export const useSearch: (filter: string | null) => string[] = (filter) => {
   const [usernames, setUsernames] = useState<string[]>([]);
-  let isMounted: boolean = true;
-  if (filter === null) {
-    isMounted = false;
-  }
+  let isMounted: boolean = filter !== null;
   const usersQuery: Query<DocumentData> = query(
     collection(db, "users"),
     where("cropsTags", "array-contains", filter)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import Home from "./routes/Home";
+import Search from "./routes/Search";
 import Post from "./routes/Post";
 import Profile from "./routes/Profile";
 import Setting from "./routes/Setting";
@@ -20,7 +21,7 @@ ReactDOM.render(
         <Routes>
           <Route path="*" element={<App />}>
             <Route path="home" element={<Home />} />
-            <Route path="search" element={<p>Search</p>} />
+            <Route path="search" element={<Search />} />
             <Route path="notifications" element={<p>Notifications</p>} />
             <Route path="email" element={<p>Email</p>} />
             <Route path="upload" element={<Upload />} />

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -1,0 +1,42 @@
+import { useSearchParams } from "react-router-dom";
+import { useSearch } from "../hooks/useSearch";
+
+const Search: React.VFC = () => {
+  const tags: string[] = ["トマト", "米"];
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = searchParams.get("tag");
+  const usernames: string[] = useSearch(filter);
+
+  return (
+    <div>
+      {tags.map((tag: string) => {
+        return (
+          <button
+            key={tag}
+            value={tag}
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.preventDefault();
+              if (searchParams.get("tag") === tag) {
+                setSearchParams({});
+              } else {
+                setSearchParams({ tag });
+              }
+            }}
+            style={
+              searchParams.get("tag") === tag
+                ? { color: "red" }
+                : { color: "white" }
+            }
+          >
+            {tag}
+          </button>
+        );
+      })}
+      {usernames.map((username: string) => {
+        return <p key={username}>{username}</p>;
+      })}
+    </div>
+  );
+};
+
+export default Search;


### PR DESCRIPTION
## Issue
#194 

## 変更した内容

src/hooks/useSearch.ts
- [x] タグ名を引数（filter）として、Firestoreから対象のユーザーのドキュメントを取得するフックスを作成
- [x] 引数（filter）が変化したタイミングのみ、getDocs()が実行されるよう、依存配列を設定

src/index.tsx
- [x] Searchコンポーネントに誘導するルートを新たに作成

src/routes/Search.tsx
- [x] タグ名を表示するボタンがクリックされた際、URLを書き換える機能を設定
- [x] 書き換えられたURLの内容が、ボタンに表示されているタグ名と一致した場合のみ、ボタンの文字色を変えるよう設定

## 動作の確認
1. tsugumonにログイン
2. 検索画面を選択
<img width="1440" alt="スクリーンショット 2022-07-22 21 49 42" src="https://user-images.githubusercontent.com/98272835/180442951-437b7837-80af-41e8-a4ea-4dc9454aa8d1.png">

3. 「トマト」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-07-22 21 49 51" src="https://user-images.githubusercontent.com/98272835/180443038-3942494a-8e20-40fb-9fb7-cdd95f91a705.png">

- [x] URLが`http://localhost:3000/search`から`http://localhost:3000/search?tag=トマト`に書き換えられていることを確認
- [x] 文字色が赤くなっていることを確認

4. 「米」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-07-22 21 49 59" src="https://user-images.githubusercontent.com/98272835/180443319-0979d73d-3388-4d49-9b6a-c4cdf18556cd.png">

- [x] URLが`http://localhost:3000/search`から`http://localhost:3000/search?tag=米`に書き換えられていることを確認
- [x] 文字色が赤くなっていることを確認

5. 「米」ボタンを再度クリック
<img width="1440" alt="スクリーンショット 2022-07-22 21 50 08" src="https://user-images.githubusercontent.com/98272835/180443519-3e5dff32-316c-4fcb-a43a-7088d86d8a5e.png">

- [x] URLが`http://localhost:3000/search?tag=米`から`http://localhost:3000/search`に書き換えられていることを確認
- [x] 文字色が平常に戻っていることを確認