### PR TITLE
✨ 検索画面でタグ検索結果に該当する投稿画像を表示する機能を実装しました

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,6 +3,7 @@ import {
   collection,
   DocumentData,
   getDocs,
+  limit,
   query,
   Query,
   QueryDocumentSnapshot,
@@ -11,34 +12,64 @@ import {
 } from "firebase/firestore";
 import { db } from "../firebase";
 
-export const useSearch: (filter: string | null) => string[] = (filter) => {
-  const [usernames, setUsernames] = useState<string[]>([]);
-  let isMounted: boolean = filter !== null;
+interface PostData {
+  avatarURL: string;
+  caption: string;
+  displayName: string;
+  id: string;
+  imageURL: string;
+  timestamp: Date;
+  uid: string;
+  username: string;
+}
+
+export const useSearch: (filter: string | null) => PostData[] = (filter) => {
+  const [posts, setPosts] = useState<PostData[]>([]);
   const usersQuery: Query<DocumentData> = query(
     collection(db, "users"),
     where("cropsTags", "array-contains", filter)
   );
-
-  const getUsername: () => void = async () => {
-    if (isMounted === false) {
-      setUsernames([]);
-    }
+  let usernames: string[] = [];
+  const getPosts: () => void = () => {
+    setPosts([]);
     getDocs(usersQuery).then((userSnaps: QuerySnapshot<DocumentData>) => {
-      setUsernames(
-        userSnaps.docs.map((userSnap: QueryDocumentSnapshot<DocumentData>) => {
+      usernames = userSnaps.docs.map(
+        (userSnap: QueryDocumentSnapshot<DocumentData>) => {
           return userSnap.data().username;
-        })
+        }
       );
+      getDocs(
+        query(
+          collection(db, "posts"),
+          where("username", "in", usernames),
+          limit(50)
+        )
+      ).then((postSnaps: QuerySnapshot<DocumentData>) => {
+        // eslint-disable-next-line array-callback-return
+        postSnaps.docs.forEach(
+          (snapshot: QueryDocumentSnapshot<DocumentData>) => {
+            const postSnap: PostData = {
+              avatarURL: snapshot.data().avatarURL,
+              caption: snapshot.data().caption,
+              displayName: snapshot.data().displayName,
+              id: snapshot.data().id,
+              imageURL: snapshot.data().imageURL,
+              timestamp: snapshot.data().timestamp,
+              uid: snapshot.data().uid,
+              username: snapshot.data().username,
+            };
+            setPosts((prev: PostData[]) => {
+              return prev.concat([postSnap]);
+            });
+          }
+        );
+      });
     });
   };
 
   useEffect(() => {
-    getUsername();
-    return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      isMounted = false;
-    };
+    getPosts();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filter]);
-
-  return usernames;
+  return posts;
 };

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -43,9 +43,10 @@ const Search: React.VFC = () => {
           </button>
         );
       })}
-      {posts.map((post: PostData) => {
-        return <img key={post.id} src={post.imageURL} alt={post.caption}/>;
-      })}
+      {posts.length > 0 &&
+        posts.map((post: PostData) => {
+          return <img key={post.id} src={post.imageURL} alt={post.caption} />;
+        })}
     </div>
   );
 };

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -1,11 +1,22 @@
 import { useSearchParams } from "react-router-dom";
 import { useSearch } from "../hooks/useSearch";
 
+interface PostData {
+  avatarURL: string;
+  caption: string;
+  displayName: string;
+  id: string;
+  imageURL: string;
+  timestamp: Date;
+  uid: string;
+  username: string;
+}
+
 const Search: React.VFC = () => {
   const tags: string[] = ["トマト", "米"];
   const [searchParams, setSearchParams] = useSearchParams();
   const filter = searchParams.get("tag");
-  const usernames: string[] = useSearch(filter);
+  const posts: PostData[] = useSearch(filter);
 
   return (
     <div>
@@ -32,8 +43,8 @@ const Search: React.VFC = () => {
           </button>
         );
       })}
-      {usernames.map((username: string) => {
-        return <p key={username}>{username}</p>;
+      {posts.map((post: PostData) => {
+        return <img key={post.id} src={post.imageURL} alt={post.caption}/>;
       })}
     </div>
   );

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -1,5 +1,6 @@
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { useSearch } from "../hooks/useSearch";
+import { Favorite } from "@mui/icons-material";
 
 interface PostData {
   avatarURL: string;
@@ -45,7 +46,29 @@ const Search: React.VFC = () => {
       })}
       {posts.length > 0 &&
         posts.map((post: PostData) => {
-          return <img key={post.id} src={post.imageURL} alt={post.caption} />;
+          return (
+            <div key={post.id}>
+              <div>
+                <p id="displayName">{post.displayName}</p>
+                {/* <p id="timestamp">{post.timestamp}</p> */}
+                <Link to={`/${post.username}`}>
+                  <img id="avatarURL" src={post.avatarURL} alt="アバター画像" />
+                </Link>
+              </div>
+              <div>
+                <Link to={`/${post.id}`}>
+                  <img src={post.imageURL} alt={post.caption} />
+                </Link>
+                <div>
+                  <Favorite />
+                  <p id="likeCounts">0</p>
+                </div>
+              </div>
+              <div>
+                <p id="caption">{post.caption}</p>
+              </div>
+            </div>
+          );
         })}
     </div>
   );


### PR DESCRIPTION
## Issue
#196 

## 変更した内容
src/hooks/useSearch.ts
- [x] 投稿データのオブジェクト型「PostData」を追加
- [x] 新たなステート「posts」を追加
- [x] 引数「filter」をキーとしてユーザー名を取得し、そのユーザー名を使用して投稿データを取得するコードを追加
- [x] 取得した投稿データの数がfirestore内の対象ドキュメント数と一致したタイミングでステートに記録するよう設定

src/routes/Search.tsx
- [x] アバター画像をクリックしたらユーザーのプロフィール画面にリンクするよう設定
- [x] 投稿画像をクリックしたら投稿画像の詳細画面にリンクするよう設定

## 動作の確認
1. tsugumonにログイン
2. 検索画面に遷移
3. コンソール画面を表示
4. 「トマト」タグをクリック
<img width="1440" alt="スクリーンショット 2022-07-25 19 06 27" src="https://user-images.githubusercontent.com/98272835/180752484-d4f9810e-d34a-42d1-98d5-ef0db83447ca.png">

- [x] アバター画像が表示されることを確認
- [x] 投稿画像が表示されることを確認
- [x] ユーザー名やキャプションが表示されることを確認

5. 「トマト」タグを再度、クリック
<img width="1440" alt="スクリーンショット 2022-07-25 19 08 06" src="https://user-images.githubusercontent.com/98272835/180752791-18daa480-ec37-4767-8d66-4635c9e07e87.png">

- [x] アバター画像や投稿画像、ユーザー名、キャプションなどすべての情報が非表示となることを確認

6. 「米」タグをクリック
7. アバター画像をクリック
<img width="1440" alt="スクリーンショット 2022-07-25 19 10 14" src="https://user-images.githubusercontent.com/98272835/180753110-3fe87489-be4e-4f1f-a64b-6f28ef455b88.png">

- [x] URLが遷移することを確認
- [x] 対象ユーザーのプロフィールが適正に表示されることを確認
