### PR TITLE
✨ 投稿データの詳細を表示するコンポーネントとリンクを実装しました

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ ReactDOM.render(
             <Route path="setting" element={<Setting />} />
           </Route>
           <Route path=":username" element={<Profile />} />
-          <Route path=":docId" element={<Post />} />
+          <Route path=":username/:docId" element={<Post />} />
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/routes/Post.tsx
+++ b/src/routes/Post.tsx
@@ -1,5 +1,4 @@
 import { memo, useState, useEffect } from "react";
-
 import { Link, Outlet, Params, useParams } from "react-router-dom";
 import { Favorite } from "@mui/icons-material";
 import { db } from "../firebase";
@@ -11,36 +10,55 @@ import {
   getDoc,
 } from "firebase/firestore";
 
+interface PostData {
+  avatarURL: string;
+  caption: string;
+  displayName: string;
+  id: string;
+  imageURL: string;
+  timestamp: number;
+  uid: string;
+  username: string;
+}
+
 const Post: React.VFC = memo(() => {
   const params: Readonly<Params<string>> = useParams();
-  const [avatarURL, setAvatarURL] = useState<string>("");
-  const [caption, setCaption] = useState<string>("");
-  const [displayName, setDisplayName] = useState<string>("");
-  const [docId, setDocId] = useState<string>("");
-  const [imageURL, setImageURL] = useState<string>("");
-  const [username, setUsername] = useState<string>("");
-  const [timestamp, setTimestamp] = useState<Date | null>(null);
+  const postId = params.docId!;
+  console.log(postId);
+  const [post, setPost] = useState<PostData>({
+    avatarURL: "",
+    caption: "",
+    displayName: "",
+    id: "",
+    imageURL: "",
+    timestamp: 0,
+    uid: "",
+    username: "",
+  });
 
-  const setPost = async (isMounted: boolean) => {
+  const getPost = async (isMounted: boolean) => {
     if (isMounted === false) {
       return;
     }
-    setDocId(params.docId!);
-    const postRef: DocumentReference<DocumentData> = doc(db, "posts", docId);
-    const postSnapshot: DocumentSnapshot<DocumentData> = await getDoc(postRef);
-    if (postSnapshot.exists()) {
-      setAvatarURL(postSnapshot.data().avatarURL);
-      setCaption(postSnapshot.data().caption);
-      setDisplayName(postSnapshot.data().displayName);
-      setImageURL(postSnapshot.data().imageURL);
-      setUsername(postSnapshot.data().username);
-      setTimestamp(postSnapshot.data().timestamp);
+    const postRef: DocumentReference<DocumentData> = doc(db, "posts", postId);
+    const postSnap: DocumentSnapshot<DocumentData> = await getDoc(postRef);
+    if (postSnap.exists()) {
+      setPost({
+        avatarURL: postSnap.data().avatarURL,
+        caption: postSnap.data().caption,
+        displayName: postSnap.data().displayName,
+        id: postSnap.id,
+        imageURL: postSnap.data().imageURL,
+        timestamp: postSnap.data().timestamp,
+        uid: postSnap.data().uid,
+        username: postSnap.data().username,
+      });
     }
   };
 
   useEffect(() => {
     let isMounted: boolean = true;
-    setPost(isMounted);
+    getPost(isMounted);
     return () => {
       isMounted = false;
     };
@@ -50,21 +68,21 @@ const Post: React.VFC = memo(() => {
   return (
     <div>
       <div>
-        <p id="displayName">{displayName}</p>
-        <p id="timestamp">{timestamp}</p>
-        <Link to={`/${username}`}>
-          <img id="avatarURL" src={avatarURL} alt="アバター画像" />
+        <p id="displayName">{post.displayName}</p>
+        {/* <p id="timestamp">{post.timestamp}</p> */}
+        <Link to={`/${post.username}`}>
+          <img id="avatarURL" src={post.avatarURL} alt="アバター画像" />
         </Link>
       </div>
       <div>
-        <img id="image" src={imageURL} alt="投稿画像" />
+        <img id="image" src={post.imageURL} alt="投稿画像" />
         <div>
           <Favorite />
           <p id="likeCounts">0</p>
         </div>
       </div>
       <div>
-        <p id="caption">{caption}</p>
+        <p id="caption">{post.caption}</p>
       </div>
       <Outlet />
     </div>

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -123,13 +123,15 @@ const Profile: React.VFC = memo(() => {
       <div>
         {posts.map((post: PostData) => {
           return (
-            <Link to={`/${post.id}`} key={post.id}>
+            <div key={post.id}>
               <img src={post.avatarURL} alt={post.username} />
               <p>{post.username}</p>
               {/* <p>{post.timestamp.getDate}</p> */}
-              <img src={post.imageURL} alt={post.id} />
-              <p>{post.caption}</p>
-            </Link>
+              <Link to={`/${username}/${post.id}`}>
+                <img src={post.imageURL} alt={post.id} />
+                <p>{post.caption}</p>
+              </Link>
+            </div>
           );
         })}
       </div>

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -56,7 +56,7 @@ const Search: React.VFC = () => {
                 </Link>
               </div>
               <div>
-                <Link to={`/${post.id}`}>
+                <Link to={`/${post.username}/${post.id}`}>
                   <img src={post.imageURL} alt={post.caption} />
                 </Link>
                 <div>


### PR DESCRIPTION
## Issue
#198 

## 変更した内容
src/index.tsx
- [x] Postコンポーネントへのパスを`ユーザー名/ドキュメントID`の形式に変更

src/routes/Post.tsx
- [x] Postコンポーネントにインターフェース`PostData`を追加
- [x] 複数のステートを`post`という一つのステートに集約
- [x] JSXで`post`ステートのtimestampを表示する箇所を非表示に変更

src/routes/Profile.tsx
- [x] `<Link />`の`to`を`ユーザー名/ドキュメントID`の形式に変更

src/routes/Search.tsx
- [x] `<Link />`の`to`を`ユーザー名/ドキュメントID`の形式に変更

## 動作の確認
1. tsugumonにログイン
2. 「プロフィールを表示する」をクリック
3. 投稿画像をクリック
![スクリーンショット 2022-07-26 21 50 35（2）](https://user-images.githubusercontent.com/98272835/181010164-e84f26bc-7bc0-410e-9541-cac08713229e.png)

- [x] Postコンポーネントが表示されることを確認
4. ホーム画面まで戻る
5. 検索画面へ遷移
6. 検索タグボタン（「トマト」・「米」など）をクリック
7. 投稿画像をクリック
- [x] Postコンポーネントが表示されることを確認