### PR TITLE
✨ いいね！ユーザーの一覧を表示するコンポーネントを実装しました

### DIFF
--- a/src/functions/AddLikes.ts
+++ b/src/functions/AddLikes.ts
@@ -35,15 +35,15 @@ export const addLikes: (postId: string, userData: UserData) => void = async (
   const likeUserSnap: DocumentSnapshot<DocumentData> = await getDoc(
     likeUserRef
   );
-  if (!likePostSnap.exists()) {
-    setDoc(likePostRef, { timestamp: new Date() });
-    if (!likeUserSnap.exists()) {
-      setDoc(likeUserRef, userData);
+  if (!likeUserSnap.exists()) {
+    setDoc(likeUserRef, userData);
+    if (!likePostSnap.exists()) {
+      setDoc(likePostRef, { timestamp: new Date() });
     }
-  } else if (likePostSnap.exists()) {
-    deleteDoc(likePostRef);
-    if (likeUserSnap.exists()) {
-      deleteDoc(likeUserRef);
+  } else if (likeUserSnap.exists()) {
+    deleteDoc(likeUserRef);
+    if (likePostSnap.exists()) {
+      deleteDoc(likePostRef);
     }
   }
 };

--- a/src/hooks/useLikeUsers.ts
+++ b/src/hooks/useLikeUsers.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect } from "react";
+import { db } from "../firebase";
+
+import {
+  collection,
+  onSnapshot,
+  QuerySnapshot,
+  DocumentData,
+  QueryDocumentSnapshot,
+  CollectionReference,
+  FirestoreError,
+} from "firebase/firestore";
+
+interface UserData {
+  avatarURL: string;
+  caption:string;
+  displayName: string;
+  uid: string;
+  username: string;
+  userType: "business" | "normal" | null;
+}
+
+export const useLikeUsers: (postId: string) => UserData[] = (
+  postId: string
+) => {
+  const [likeUsers, setLikeUsers] = useState<UserData[]>([]);
+
+  const unsubscribe: (isMounted: boolean) => void = async (isMounted) => {
+    if (isMounted === false || postId === "") {
+      return;
+    }
+    const likeUsersRef: CollectionReference<DocumentData> = collection(
+      db,
+      `posts/${postId}/likeUsers/`
+    );
+
+    onSnapshot(
+      likeUsersRef,
+      (snapshots: QuerySnapshot<DocumentData>) => {
+        setLikeUsers(
+          snapshots.docs.map(
+            (snapshot: QueryDocumentSnapshot<DocumentData>) => {
+              const likeUser: UserData = {
+                avatarURL: snapshot.data().avatarURL,
+                caption: snapshot.data().caption,
+                displayName: snapshot.data().displayName,
+                uid: snapshot.id,
+                username: snapshot.data().username,
+                userType: snapshot.data().userType,
+              };
+              return likeUser;
+            }
+          )
+        );
+      },
+      (error: FirestoreError) => {
+        if (process.env.NODE_ENV === "development") {
+          console.error(error);
+        }
+      }
+    );
+  };
+
+  useEffect(() => {
+    let isMounted: boolean = true;
+    unsubscribe(isMounted);
+    return () => {
+      isMounted = false;
+      unsubscribe(isMounted);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return likeUsers;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import Home from "./routes/Home";
 import Search from "./routes/Search";
 import Post from "./routes/Post";
+import Likes from "./routes/LikeUsers";
 import Profile from "./routes/Profile";
 import Setting from "./routes/Setting";
 import SignUp from "./routes/SignUp";
@@ -30,6 +31,7 @@ ReactDOM.render(
           </Route>
           <Route path=":username" element={<Profile />} />
           <Route path=":username/:docId" element={<Post />} />
+          <Route path=":username/:docId/likeUsers" element={<Likes />} />
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/routes/LikeUsers.tsx
+++ b/src/routes/LikeUsers.tsx
@@ -1,8 +1,17 @@
 import React, { memo } from "react";
-import { Link, Outlet, useNavigate, NavigateFunction } from "react-router-dom";
+import {
+  Link,
+  Outlet,
+  useNavigate,
+  NavigateFunction,
+  useParams,
+  Params,
+} from "react-router-dom";
+import { useLikeUsers } from "../hooks/useLikeUsers";
 
 interface UserData {
   avatarURL: string;
+  caption: string;
   displayName: string;
   uid: string;
   username: string;
@@ -10,7 +19,35 @@ interface UserData {
 }
 
 const LikeUsers: React.VFC = memo(() => {
-  return <div></div>;
+  const params: Readonly<Params<string>> = useParams();
+  const postId: string = params.docId!;
+  const navigate: NavigateFunction = useNavigate();
+  const likeUsers: UserData[] = useLikeUsers(postId);
+
+  return (
+    <div>
+      <button
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          event.preventDefault();
+          navigate(-1);
+        }}
+      >
+        戻る
+      </button>
+      {likeUsers.map((likeUser: UserData) => {
+        return (
+          <Link to={`/${likeUser.username}`} key={likeUser.uid}>
+            <div>
+              <img src={likeUser.avatarURL} alt={likeUser.username} />
+              <p>{likeUser.displayName}</p>
+              <p>{likeUser.caption}</p>
+            </div>
+          </Link>
+        );
+      })}
+      <Outlet />
+    </div>
+  );
 });
 
 export default LikeUsers;

--- a/src/routes/LikeUsers.tsx
+++ b/src/routes/LikeUsers.tsx
@@ -1,0 +1,16 @@
+import React, { memo } from "react";
+import { Link, Outlet, useNavigate, NavigateFunction } from "react-router-dom";
+
+interface UserData {
+  avatarURL: string;
+  displayName: string;
+  uid: string;
+  username: string;
+  userType: "business" | "normal" | null;
+}
+
+const LikeUsers: React.VFC = memo(() => {
+  return <div></div>;
+});
+
+export default LikeUsers;

--- a/src/routes/Post.tsx
+++ b/src/routes/Post.tsx
@@ -53,7 +53,7 @@ const Post: React.VFC = memo(() => {
     username: user.username,
     userType: user.userType,
   };
-  const [counts, setCounts] = useState<number | null>(null);
+  const [likeUsers, setLikeUsers] = useState<UserData[]>([]);
   const [post, setPost] = useState<PostData>({
     avatarURL: "",
     caption: "",
@@ -87,8 +87,19 @@ const Post: React.VFC = memo(() => {
         db,
         `posts/${postSnap.id}/likeUsers`
       );
-      onSnapshot(likeUsersRef, (likeUsersSnap:QuerySnapshot<DocumentData>) => {
-        setCounts(likeUsersSnap.size);
+      onSnapshot(likeUsersRef, (likeUsersSnap: QuerySnapshot<DocumentData>) => {
+        setLikeUsers(
+          likeUsersSnap.docs.map((likeUserSnap) => {
+            const likeUser = {
+              avatarURL: likeUserSnap.data().avatarURL,
+              displayName: likeUserSnap.data().displayName,
+              uid: likeUserSnap.data().uid,
+              username: likeUserSnap.data().username,
+              userType: likeUserSnap.data().userType,
+            };
+            return likeUser;
+          })
+        );
       });
     }
   };
@@ -128,7 +139,9 @@ const Post: React.VFC = memo(() => {
               addLikes(postId, userData);
             }}
           />
-          <p id="likeCounts">{counts}</p>
+          <Link to={`/${post.username}/${postId}/likeUsers`}>
+            <p id="likeCounts">{likeUsers.length}</p>
+          </Link>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Issue
#204 

## 変更した内容
src/hooks/useLikeUsers.ts
- [x] Firestoreから取得したいいねユーザーのデータを格納するステートとして`likeUsers`を設定
- [x] 引数`postId`をキーとして、いいねユーザーコレクションを参照するよう設定
- [x] onSnapshotでリアルタイムにいいねユーザーのコレクションの中身を反映するよう設定
- [x] useLikeUsersからは、いいねユーザーの配列をリターンするようにした

src/index.tsx
- [x] 新しいルートとして`<Route path=":username/:docId/likeUsers" element={<Likes />} />`を追加

src/routes/LikeUsers.tsx
- [x] いいねユーザーの一覧を表示するコンポーネントとして`LikeUsers.tsx`を作成
- [x] それぞれのいいねユーザーに対して、各ユーザーのプロフィール画面へのリンクを作成

src/routes/Post.tsx
- [x] likeUsersにログインしているユーザーが含まれるか否かを判定し、含まれていたらステート`like`をtrueに変えるよう設定
- [x] ステート`like`がtrueの場合は、文字色を赤色に変更するよう設定
- [x] いいねユーザー数が0の場合は、likeUsersへのリンクが起動しないよう設定


## 動作の確認
1. tsugumonにログインし、「プロフィールを表示する」をクリック
2. 任意の投稿画像をクリックし、投稿内容の詳細画面へ遷移
3. いいね数が０の場合、数字０をクリック
- [x] リンクが起動しないことを確認
- [x] いいねボタンをクリックし、数字が０から１へと変化することと、色が変化することを確認
4. いいね数が０より大きい場合、数字をクリック
<img width="1440" alt="スクリーンショット 2022-07-30 20 30 42" src="https://user-images.githubusercontent.com/98272835/181909136-b9ec5d13-9198-411b-9670-48a85ee18c1a.png">

- [x] いいねユーザーの一覧が表示されることを確認
6. ホーム画面まで戻る
7. 検索画面に遷移
8. 任意のタグで検索
9. 任意の投稿画像をクリックし、投稿内容の詳細画面へ遷移
- [ ] いいね数が適切に反映されていることを確認

<img width="1440" alt="スクリーンショット 2022-07-30 20 36 12" src="https://user-images.githubusercontent.com/98272835/181909158-c57475ef-59a6-47b0-89d7-0f7fa780ed09.png">

