### PR TITLE
✨ Firestoreにドキュメントを作成するフォローボタンを実装しました

### DIFF
--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "../app/store";
 
-export interface User {
+export interface LoginUser {
   uid: string;
   username: string;
   displayName: string;
@@ -22,11 +22,11 @@ export interface UserLogin {
   avatarURL: string;
 }
 
-const initialState: User = {
+const initialState: LoginUser = {
+  avatarURL: "",
+  displayName: "",
   uid: "",
   username: "",
-  displayName: "",
-  avatarURL: "",
   userType: null,
   isNewUser: false,
 };

--- a/src/functions/AddFollower.ts
+++ b/src/functions/AddFollower.ts
@@ -1,0 +1,50 @@
+import { db } from "../firebase";
+import {
+  doc,
+  DocumentData,
+  DocumentSnapshot,
+  getDoc,
+  setDoc,
+  deleteDoc,
+} from "firebase/firestore";
+
+interface UserData {
+  avatarURL: string;
+  displayName: string;
+  username: string;
+  userType: "business" | "normal" | null;
+}
+
+export const addFollower: (
+  followerUID: string,
+  followingUID: string,
+  followerData: UserData,
+  followingData: UserData
+) => void = async (
+  followerUID,
+  followingUID,
+  followerData,
+  followingData
+) => {
+  const followerRef = doc(db, `users/${followingUID}/followers/${followerUID}`);
+  const followingRef = doc(
+    db,
+    `users/${followerUID}/followings/${followingUID}`
+  );
+  const followerSnap: DocumentSnapshot<DocumentData> = await getDoc(
+    followerRef
+  );
+  const followingSnap: DocumentSnapshot<DocumentData> = await getDoc(
+    followingRef
+  );
+  if (!followerSnap.exists()) {
+    setDoc(followerRef, followerData);
+  } else {
+    deleteDoc(followerRef);
+  }
+  if (!followingSnap.exists()) {
+    setDoc(followingRef, followingData);
+  } else {
+    deleteDoc(followingRef);
+  }
+};

--- a/src/functions/AddFollower.ts
+++ b/src/functions/AddFollower.ts
@@ -8,28 +8,25 @@ import {
   deleteDoc,
 } from "firebase/firestore";
 
-interface UserData {
+interface FollowUser {
   avatarURL: string;
   displayName: string;
+  uid: string;
   username: string;
   userType: "business" | "normal" | null;
 }
 
 export const addFollower: (
-  followerUID: string,
-  followingUID: string,
-  followerData: UserData,
-  followingData: UserData
-) => void = async (
-  followerUID,
-  followingUID,
-  followerData,
-  followingData
-) => {
-  const followerRef = doc(db, `users/${followingUID}/followers/${followerUID}`);
+  following: FollowUser,
+  follower: FollowUser
+) => void = async (following, follower) => {
+  const followerRef = doc(
+    db,
+    `users/${following.uid}/followers/${follower.uid}`
+  );
   const followingRef = doc(
     db,
-    `users/${followerUID}/followings/${followingUID}`
+    `users/${follower.uid}/followings/${following.uid}`
   );
   const followerSnap: DocumentSnapshot<DocumentData> = await getDoc(
     followerRef
@@ -38,12 +35,12 @@ export const addFollower: (
     followingRef
   );
   if (!followerSnap.exists()) {
-    setDoc(followerRef, followerData);
+    setDoc(followerRef, follower);
   } else {
     deleteDoc(followerRef);
   }
   if (!followingSnap.exists()) {
-    setDoc(followingRef, followingData);
+    setDoc(followingRef, following);
   } else {
     deleteDoc(followingRef);
   }

--- a/src/hooks/useBatch.ts
+++ b/src/hooks/useBatch.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAppSelector } from "../app/hooks";
-import { selectUser, User } from "../features/userSlice";
+import { selectUser, LoginUser } from "../features/userSlice";
 import { db, storage } from "../firebase";
 import {
   ref,
@@ -47,7 +47,7 @@ export const useBatch: (
   postImage: string,
   caption: string
 ) => "wait" | "run" | "done" = (upload, postImage, caption) => {
-  const user: User = useAppSelector(selectUser);
+  const user: LoginUser = useAppSelector(selectUser);
   const uid: string = user.uid;
   const username: string = user.username;
   const displayName: string = user.displayName;

--- a/src/hooks/useFeeds.ts
+++ b/src/hooks/useFeeds.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAppSelector } from "../app/hooks";
-import { selectUser, User } from "../features/userSlice";
+import { selectUser, LoginUser } from "../features/userSlice";
 import { db } from "../firebase";
 import {
   collection,
@@ -29,7 +29,7 @@ export const useFeeds: () => PostData[] = () => {
   if (process.env.NODE_ENV === "development") {
     console.log("useFeeds.tsがレンダリングされました");
   }
-  const user: User = useAppSelector(selectUser);
+  const user: LoginUser = useAppSelector(selectUser);
   const [feeds, setFeeds] = useState<PostData[]>([]);
   let updatedFeeds: PostData[] = [];
   let sortedFeeds: PostData[] = [];

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect} from "react";
+import { useState, useEffect } from "react";
 import { db } from "../firebase";
 import {
   collection,
@@ -24,12 +24,8 @@ interface PostData {
 
 export const usePosts = (username: string) => {
   const [posts, setPosts] = useState<PostData[]>([]);
-  let isMounted:boolean = true;
-
+  let isMounted = true;
   const unsubscribe: () => void = async () => {
-    if (isMounted === false) {
-      return;
-    }
     const postsQuery: Query<DocumentData> = query(
       collection(db, "posts"),
       where("username", "==", username)
@@ -38,7 +34,7 @@ export const usePosts = (username: string) => {
     onSnapshot(
       postsQuery,
       (snapshots: QuerySnapshot<DocumentData>) => {
-        const unChangedPosts:PostData[] = posts;
+        const unChangedPosts: PostData[] = posts;
         const changedPosts: PostData[] = snapshots.docs.map(
           (snapshot: QueryDocumentSnapshot<DocumentData>) => {
             const changedPost: PostData = {
@@ -57,7 +53,9 @@ export const usePosts = (username: string) => {
             return changedPost;
           }
         );
-        setPosts(unChangedPosts.concat(changedPosts));
+        if (isMounted === true) {
+          setPosts(unChangedPosts.concat(changedPosts));
+        }
       },
       (error) => {
         console.error(error);
@@ -66,10 +64,9 @@ export const usePosts = (username: string) => {
   };
 
   useEffect(() => {
-    let isMounted = true;
     unsubscribe();
     return () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       isMounted = false;
       unsubscribe();
     };
@@ -78,4 +75,3 @@ export const usePosts = (username: string) => {
   console.log(posts);
   return posts;
 };
-

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect} from "react";
 import { db } from "../firebase";
 import {
   collection,
@@ -24,8 +24,9 @@ interface PostData {
 
 export const usePosts = (username: string) => {
   const [posts, setPosts] = useState<PostData[]>([]);
+  let isMounted:boolean = true;
 
-  const unsubscribe: (isMounted: boolean) => void = async (isMounted) => {
+  const unsubscribe: () => void = async () => {
     if (isMounted === false) {
       return;
     }
@@ -66,10 +67,11 @@ export const usePosts = (username: string) => {
 
   useEffect(() => {
     let isMounted = true;
-    unsubscribe(isMounted);
+    unsubscribe();
     return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       isMounted = false;
-      unsubscribe(isMounted);
+      unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -15,6 +15,7 @@ interface UserData {
   cropsTags: string[];
   displayName: string;
   introduction: string;
+  username: string;
   userType: "business" | "normal" | null;
 }
 
@@ -33,6 +34,7 @@ export const useProfile = (username: string) => {
     cropsTags: [],
     displayName: "",
     introduction: "",
+    username: "",
     userType: null,
   });
   const [option, setOption] = useState<OptionData>({
@@ -42,6 +44,7 @@ export const useProfile = (username: string) => {
     skill: "",
     typeOfWork: "",
   });
+  const [uid, setUid] = useState<string>("");
   let isMounted: boolean = true;
 
   const getUser = async () => {
@@ -59,8 +62,10 @@ export const useProfile = (username: string) => {
       cropsTags: userSnap.docs[0].data().cropsTags,
       displayName: userSnap.docs[0].data().displayName,
       introduction: userSnap.docs[0].data().introduction,
+      username: userSnap.docs[0].data().username,
       userType: userSnap.docs[0].data().userType,
     });
+    setUid(userSnap.docs[0].id);
   };
 
   const getOption = async () => {
@@ -91,7 +96,7 @@ export const useProfile = (username: string) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   if (user && option) {
-    console.log({ user: user, option: option });
-    return { user: user, option: option };
+    console.log({ user: user, option: option ,uid:uid});
+    return { user: user, option: option, uid: uid };
   }
 };

--- a/src/routes/Post.tsx
+++ b/src/routes/Post.tsx
@@ -8,7 +8,7 @@ import {
   NavigateFunction,
 } from "react-router-dom";
 import { useAppSelector } from "../app/hooks";
-import { selectUser, User } from "../features/userSlice";
+import { selectUser, LoginUser } from "../features/userSlice";
 import { addLikes } from "../functions/AddLikes";
 import { Favorite } from "@mui/icons-material";
 import { db } from "../firebase";
@@ -46,7 +46,7 @@ interface PostData {
 
 const Post: React.VFC = memo(() => {
   const params: Readonly<Params<string>> = useParams();
-  const user: User = useAppSelector(selectUser);
+  const user: LoginUser = useAppSelector(selectUser);
   const userData: UserData = {
     avatarURL: user.avatarURL,
     displayName: user.displayName,

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, memo } from "react";
+import React, { memo } from "react";
 import {
   Link,
   Outlet,
@@ -7,44 +7,11 @@ import {
   useNavigate,
   NavigateFunction,
 } from "react-router-dom";
-import { useAppSelector } from "../app/hooks";
-import { db } from "../firebase";
-import { selectUser } from "../features/userSlice";
 import { useProfile } from "../hooks/useProfile";
 import { usePosts } from "../hooks/usePosts";
 import { addFollower } from "../functions/AddFollower";
-import {
-  collection,
-  CollectionReference,
-  DocumentData,
-  getDocs,
-  onSnapshot,
-  Query,
-  query,
-  QueryDocumentSnapshot,
-  QuerySnapshot,
-  where,
-} from "firebase/firestore";
 
-interface UserData {
-  avatarURL: string;
-  backgroundURL: string;
-  cropsTags: string[];
-  displayName: string;
-  introduction: string;
-  username: string;
-  userType: "business" | "normal" | null;
-}
-
-interface OptionData {
-  address: string;
-  birthdate: string;
-  owner: string;
-  skill: string;
-  typeOfWork: string;
-}
-
-interface PostData {
+interface Post {
   avatarURL: string;
   caption: string;
   displayName: string;
@@ -55,64 +22,27 @@ interface PostData {
   username: string;
 }
 
+interface FollowUser {
+  avatarURL: string;
+  displayName: string;
+  uid: string;
+  username: string;
+  userType: "business" | "normal" | null;
+}
+
 const Profile: React.VFC = memo(() => {
-  const [followersCount, setFollowersCount] = useState<number | null>(null);
-  const [followingsCount, setFollowingsCount] = useState<number | null>(null);
-  const [follow, setFollow] = useState<boolean>(false);
   const params: Readonly<Params<string>> = useParams();
-  const currentUser = useAppSelector(selectUser);
-  const followerUID = currentUser.uid;
-  const username = params.username!;
+  const username: string = params.username!;
   const navigate: NavigateFunction = useNavigate();
-  const user: UserData = useProfile(username)!.user;
-  const uid: string = useProfile(username)!.uid;
-  const option: OptionData = useProfile(username)!.option;
-  const posts: PostData[] = usePosts(username);
-
-  const getFollowers = async (isMounted: boolean) => {
-    if (isMounted === false) {
-      return;
-    }
-    
-    const followingQuery: Query<DocumentData> = query(
-      collection(db, "users"),
-      where("username", "==", username)
-    );
-    getDocs(followingQuery).then(
-      (followingsSnap: QuerySnapshot<DocumentData>) => {
-    const followersRef: CollectionReference<DocumentData> = collection(
-      db,
-      `users/${followingsSnap.docs[0].id}/followers`
-    );
-    const followingsRef: CollectionReference<DocumentData> = collection(
-      db,
-      `users/${followingsSnap.docs[0].id}/followings`
-    );
-    onSnapshot(followersRef, (followersSnap: QuerySnapshot<DocumentData>) => {
-      setFollowersCount(followersSnap.size);
-      setFollow(
-        followersSnap.docs.find(
-          (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
-            return followerSnap.id === followerUID;
-          }
-        ) !== undefined
-      );
-    });
-
-    onSnapshot(followingsRef, (followingsSnap: QuerySnapshot<DocumentData>) => {
-      setFollowingsCount(followingsSnap.size);
-    });
-  });
-  };
-
-  useEffect(() => {
-    let isMounted: boolean = true;
-    getFollowers(isMounted);
-    return () => {
-      isMounted = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const {
+    user,
+    option,
+    followingsCount,
+    followersCount,
+    isFollowing,
+    loginUser,
+  } = useProfile(username)!;
+  const posts: Post[] = usePosts(username);
 
   return (
     <div>
@@ -135,7 +65,7 @@ const Profile: React.VFC = memo(() => {
           }
           alt="アバター画像"
         />
-        {currentUser.username === username ? (
+        {loginUser.uid === user.uid ? (
           <Link to="/setting">
             <p>プロフィールを編集する</p>
           </Link>
@@ -143,11 +73,24 @@ const Profile: React.VFC = memo(() => {
           <button
             onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
               event.preventDefault();
-              console.log("フォローボタンが押されました");
-              addFollower(followerUID, uid, currentUser, user);
+              const following: FollowUser = {
+                avatarURL: user.avatarURL,
+                displayName: user.displayName,
+                uid: user.uid,
+                username: user.username,
+                userType: user.userType,
+              };
+              const follower: FollowUser = {
+                avatarURL: loginUser.avatarURL,
+                displayName: loginUser.displayName,
+                uid: loginUser.uid,
+                username: loginUser.username,
+                userType: loginUser.userType,
+              };
+              addFollower(following, follower);
             }}
           >
-            {follow ? "フォロー解除" : "フォローする"}
+            {isFollowing ? "フォロー解除" : "フォローする"}
           </button>
         )}
         <p id="displayName">{user.displayName}</p>
@@ -162,22 +105,22 @@ const Profile: React.VFC = memo(() => {
         </div>
         <div id="followerCounts">
           <p>フォロワー</p>
-          {followersCount === null || followersCount === 0 ? (
-            <p>{followersCount}</p>
-          ) : (
+          {followersCount > 0 ? (
             <Link to={`/users/${username}/followers`}>
               <p>{followersCount}</p>
             </Link>
+          ) : (
+            <p>{followersCount}</p>
           )}
         </div>
         <div id="followingCounts">
           <p>フォロー中</p>
-          {followingsCount === null || followingsCount === 0 ? (
-            <p>{followingsCount}</p>
-          ) : (
+          {followingsCount > 0 ? (
             <Link to={`/users/${username}/followings`}>
               <p>{followingsCount}</p>
             </Link>
+          ) : (
+            <p>{followingsCount}</p>
           )}
         </div>
         {user.userType === "business" ? (
@@ -208,7 +151,7 @@ const Profile: React.VFC = memo(() => {
         )}
       </div>
       <div>
-        {posts.map((post: PostData) => {
+        {posts.map((post: Post) => {
           return (
             <div key={post.id}>
               <img src={post.avatarURL} alt={post.username} />

--- a/src/routes/Upload.tsx
+++ b/src/routes/Upload.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, memo } from "react";
 import { useNavigate, NavigateFunction } from "react-router-dom";
 import { useAppSelector } from "../app/hooks";
-import { selectUser, User } from "../features/userSlice";
+import { selectUser, LoginUser } from "../features/userSlice";
 import { useBatch } from "../hooks/useBatch";
 import { AddPhotoAlternate, Cancel } from "@mui/icons-material";
 import { resizeImage } from "../functions/ResizeImage";
 
 const Upload: React.FC = memo(() => {
-  const user: User = useAppSelector(selectUser);
+  const user: LoginUser = useAppSelector(selectUser);
   const displayName: string = user.displayName;
   const avatarURL: string = user.avatarURL;
   const [postImage, setPostImage] = useState<string>("");


### PR DESCRIPTION
## Issue
#208 

## 変更した内容

src/features/userSlice.ts
- [x] インターフェース名を`User`から`LoginUser`に変更（他コンポーネントのインターフェース名と重複し紛らわしかったため）

src/functions/AddFollower.ts
- [x] インターフェース`FollowUser`で規定した型のオブジェクトを引数として、対象ユーザーの「フォロー中」ドキュメントと「フォロワー」ドキュメントをFirestore上に作成する関数を作成した

src/hooks/usePosts.ts
- [x] フックス内部に、メモリリークの原因となる「onSnapshotのクリーンアップに関するミスコード」と「アンマウント時のステート更新」という不備が見つかったので修正した

src/hooks/useProfile.ts
- [x] 返り値`user`オブジェクトの中に`uid`の情報を追加
- [x] フックス内部に、メモリリークの原因となる「onSnapshotのクリーンアップに関するミスコード」と「アンマウント時のステート更新」という不備が見つかったので修正した
- [x] ProfileコンポーネントでおこなっていたonsSnapshotを用いてのフォロワー数取得処理をuseProfile.tsに移行した
- [x] フォロワー数(`followersCount`)やフォロー中の数(`followingsCount`)も返り値として返すよう変更


## 動作の確認
1. tsugumonにログイン
2. 検索画面で任意のタグをクリック
3. 表示された投稿一覧のうち、ログインユーザー以外の任意の投稿のアバター画像をクリック
4. ユーザーのプロフィール画面に移動する
![スクリーンショット 2022-08-02 22 08 02（2）](https://user-images.githubusercontent.com/98272835/182382846-5c224bcc-93d7-4067-9223-7342fb3cefaa.png)
![スクリーンショット 2022-08-02 22 07 45（2）](https://user-images.githubusercontent.com/98272835/182382871-6ac04480-a3c9-4697-858e-ca1f8a3d56dc.png)

- [x] プロフィール画面に表示されている「フォロー中」の数と「フォロワー」数が、Firestoreの「Followings」のドキュメント数と「Followers」のドキュメント数と一致していることを確認

6. フォローする（フォロー解除）ボタンをクリック
![スクリーンショット 2022-08-02 22 08 20（2）](https://user-images.githubusercontent.com/98272835/182383951-9aa3adb9-e859-4edb-80e3-10d868c1676e.png)

![スクリーンショット 2022-08-02 22 08 13（2）](https://user-images.githubusercontent.com/98272835/182383423-257ec047-3882-4528-a0f9-97923af478b6.png)

- [x] ボタンの内容に合わせて、表示画面上のフォロワー数が適切に増減することを確認
- [x] ボタンの内容に合わせて、Firestoreの「Followings」のドキュメント数と「Followers」のドキュメント数が適切に増減することを確認

7. 検索画面から別の画面へと遷移
![スクリーンショット 2022-08-02 22 09 01（2）](https://user-images.githubusercontent.com/98272835/182384121-f115f135-a763-41de-bc63-23e043485576.png)

- [x] クリーンアップ関数の不備によるメモリリークエラーが、コンソール画面に表示されないことを確認

