### PR TITLE
✨ Follower一覧を表示するコンポーネントとフックスを作成しました

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ const App: React.FC = () => {
       auth,
       async (authUser: User | null) => {
         if (authUser) {
+          let introduction: string = "";
           let userType: "business" | "normal" | null = null;
           let username: string = "";
           const userRef: DocumentReference<DocumentData> = doc(
@@ -36,6 +37,7 @@ const App: React.FC = () => {
             userRef
           );
           if (userSnap.exists()) {
+            introduction = userSnap.data().introduction;
             userType = userSnap.data().userType;
             username = userSnap.data().username;
           } else {
@@ -44,10 +46,11 @@ const App: React.FC = () => {
 
           dispatch(
             login({
+              avatarURL: authUser.photoURL ? authUser.photoURL : "",
+              displayName: authUser.displayName ? authUser.displayName : "",
+              introduction: introduction,
               uid: authUser.uid,
               username: username,
-              displayName: authUser.displayName ? authUser.displayName : "",
-              avatarURL: authUser.photoURL ? authUser.photoURL : "",
               userType: userType,
             })
           );

--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -2,33 +2,36 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "../app/store";
 
 export interface LoginUser {
-  uid: string;
-  username: string;
-  displayName: string;
-  userType: "business" | "normal" | null;
   avatarURL: string;
+  displayName: string;
+  introduction: string;
   isNewUser: boolean;
+  uid: string;
+  userType: "business" | "normal" | null;
+  username: string;
 }
 export interface UserProfile {
+  avatarURL: string;
   displayName: string;
   username: string;
-  avatarURL: string;
 }
 export interface UserLogin {
-  uid: string;
-  username: string;
-  displayName: string;
-  userType: "business" | "normal" | null;
   avatarURL: string;
+  displayName: string;
+  introduction: string;
+  uid: string;
+  userType: "business" | "normal" | null;
+  username: string;
 }
 
 const initialState: LoginUser = {
   avatarURL: "",
   displayName: "",
-  uid: "",
-  username: "",
-  userType: null,
+  introduction:"",
   isNewUser: false,
+  uid: "",
+  userType: null,
+  username: "",
 };
 
 export const userSlice = createSlice({
@@ -36,18 +39,20 @@ export const userSlice = createSlice({
   initialState: initialState,
   reducers: {
     login: (state, action: PayloadAction<UserLogin>) => {
+      state.avatarURL = action.payload.avatarURL;
+      state.displayName = action.payload.displayName;
+      state.introduction = action.payload.introduction;
       state.uid = action.payload.uid;
       state.username = action.payload.username;
-      state.displayName = action.payload.displayName;
       state.userType = action.payload.userType;
-      state.avatarURL = action.payload.avatarURL;
     },
     logout: (state: UserLogin) => {
+      state.avatarURL = "";
+      state.displayName = "";
+      state.introduction ="";
       state.uid = "";
       state.username = "";
-      state.displayName = "";
       state.userType = null;
-      state.avatarURL = "";
     },
     setUserProfile: (state, action: PayloadAction<UserProfile>) => {
       state.displayName = action.payload.displayName;

--- a/src/functions/AddFollower.ts
+++ b/src/functions/AddFollower.ts
@@ -11,6 +11,7 @@ import {
 interface FollowUser {
   avatarURL: string;
   displayName: string;
+  introduction: string;
   uid: string;
   username: string;
   userType: "business" | "normal" | null;

--- a/src/hooks/useFollowers.ts
+++ b/src/hooks/useFollowers.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react";
+import { db } from "../firebase";
+import {
+  collection,
+  QuerySnapshot,
+  DocumentData,
+  QueryDocumentSnapshot,
+  where,
+  query,
+  Query,
+  getDocs,
+  CollectionReference,
+} from "firebase/firestore";
+
+interface Follower {
+  avatarURL: string;
+  displayName: string;
+  introduction: string;
+  uid: string;
+  userType: "business" | "normal" | null;
+  username: string;
+}
+
+export const useFollowers: (username: string) => Follower[] = (username) => {
+  const [followers, setFollowers] = useState<Follower[]>([]);
+  let isMounted: boolean = true;
+  const userQuery: Query<DocumentData> = query(
+    collection(db, "users"),
+    where("username", "==", username)
+  );
+  const unsubscribe = async () => {
+    const uid: string = (await getDocs(userQuery)).docs[0].id;
+    const followersRef: CollectionReference = collection(
+      db,
+      `users/${uid}/followers`
+    );
+    const followersSnap: QuerySnapshot<DocumentData> = await getDocs(
+      followersRef
+    );
+    if (isMounted === true) {
+      setFollowers(
+        followersSnap.docs.map(
+          (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
+            return {
+              avatarURL: followerSnap.data().avatarURL,
+              displayName: followerSnap.data().displayName,
+              introduction: followerSnap.data().introduction,
+              uid: followerSnap.id,
+              userType: followerSnap.data().userType,
+              username: followerSnap.data().username,
+            };
+          }
+        )
+      );
+    }
+  };
+  useEffect(() => {
+    unsubscribe();
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+  return followers;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App";
+import Followers from "./routes/Followers";
 import Home from "./routes/Home";
 import Search from "./routes/Search";
 import Post from "./routes/Post";
@@ -31,6 +32,7 @@ ReactDOM.render(
             <Route path=":username" element={<Profile />} />
             <Route path=":username/:docId" element={<Post />} />
             <Route path=":username/:docId/likeUsers" element={<LikeUsers />} />
+            <Route path=":username/followers" element={<Followers />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/routes/Followers.tsx
+++ b/src/routes/Followers.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import {
+  Link,
+  Outlet,
+  useNavigate,
+  NavigateFunction,
+  useParams,
+  Params,
+} from "react-router-dom";
+import { useFollowers } from "../hooks/useFollowers";
+
+interface Follower {
+  avatarURL: string;
+  displayName: string;
+  introduction: string;
+  uid: string;
+  userType: "business" | "normal" | null;
+  username: string;
+}
+
+const Followers: React.VFC = () => {
+  const params: Readonly<Params<string>> = useParams();
+  const username: string = params.username!;
+  const navigate: NavigateFunction = useNavigate();
+  const followers: Follower[] = useFollowers(username);
+
+  return (
+    <div>
+      <button
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          event.preventDefault();
+          navigate(-1);
+        }}
+      >
+        戻る
+      </button>
+      {followers.map((follower: Follower) => {
+        return (
+          <Link to={`/${follower.username}`} key={follower.username}>
+            <div>
+              <img src={follower.avatarURL} alt={follower.username} />
+              <p>{follower.displayName}</p>
+              <p>{follower.introduction}</p>
+            </div>
+          </Link>
+        );
+      })}
+      <Outlet />
+    </div>
+  );
+};
+
+export default Followers;

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -25,6 +25,7 @@ interface Post {
 interface FollowUser {
   avatarURL: string;
   displayName: string;
+  introduction: string;
   uid: string;
   username: string;
   userType: "business" | "normal" | null;
@@ -76,6 +77,7 @@ const Profile: React.VFC = memo(() => {
               const following: FollowUser = {
                 avatarURL: user.avatarURL,
                 displayName: user.displayName,
+                introduction: user.introduction,
                 uid: user.uid,
                 username: user.username,
                 userType: user.userType,
@@ -83,6 +85,7 @@ const Profile: React.VFC = memo(() => {
               const follower: FollowUser = {
                 avatarURL: loginUser.avatarURL,
                 displayName: loginUser.displayName,
+                introduction: loginUser.introduction,
                 uid: loginUser.uid,
                 username: loginUser.username,
                 userType: loginUser.userType,
@@ -104,19 +107,22 @@ const Profile: React.VFC = memo(() => {
           })}
         </div>
         <div id="followerCounts">
-          <p>フォロワー</p>
           {followersCount > 0 ? (
-            <Link to={`/users/${username}/followers`}>
+            <Link to={`/${username}/followers`}>
+              <p>フォロワー</p>
               <p>{followersCount}</p>
             </Link>
           ) : (
-            <p>{followersCount}</p>
+            <>
+              <p>フォロワー</p>
+              <p>{followersCount}</p>
+            </>
           )}
         </div>
         <div id="followingCounts">
           <p>フォロー中</p>
           {followingsCount > 0 ? (
-            <Link to={`/users/${username}/followings`}>
+            <Link to={`/${username}/followings`}>
               <p>{followingsCount}</p>
             </Link>
           ) : (


### PR DESCRIPTION
## Issue
#210 

## 変更した内容
src/features/userSlice.ts
- [x] useSliceの初期ステートに`introduction`を追加

src/functions/AddFollower.ts
- [x] 引数FollowUserの型interfaceに`introduction`を追加

src/hooks/useFollowers.ts
- [x] 引数usernameをキーとしてUIDを取得し、そのUIDを持つユーザーのfollowersサブコレクションを取得するよう指定
- [x] 上記の一連の処理を`useEffect`で実行。取得したfollowersコレクションをステートに書き込み、最終的にリターンするよう設定

src/index.tsx
- [x] インポートするモジュールにFollowersコンポーネントを追加
- [x] Followersコンポーネントへのルートを設定

src/routes/Followers.tsx
- [x] `useParams`を使って、URLから抽出したユーザー名を引数として、`useFollowers`を実行するよう設定
- [x] `useFollowers`からの返り値をもとにJSXを展開するよう設定

src/routes/Profile.tsx
- [x] 「フォロワー」の文字とフォロワー数をクリックしたら、FollowersコンポーネントのURLへリンクするよう設定

## 動作の確認
1. tsugumonにログイン
2. 任意のユーザーのプロフィール画面を表示
3. 「フォロワー」もしくはフォロワー数をクリック
![スクリーンショット 2022-08-03 21 48 27（2）](https://user-images.githubusercontent.com/98272835/182612047-750f507c-0439-4b51-93e3-ff2b5ccca790.png)

- [x] フォロワーの簡易プロフィールが適切に表示されていることを確認
4. 「戻る」ボタンをクリック

- [x] 履歴を遡る処理が実行されることを確認
5. 再度、Followersコンポーネントまで遷移
6. 現在の画面とは異なるメニュータブの画面に遷移
- [x] メモリリークエラーが起きないことを確認

