### PR TITLE
👍 ユーザーの検索結果を表示する画面に「いいね」数を実装しました

### DIFF
--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -1,0 +1,145 @@
+import React, { memo, useState, useEffect } from "react";
+import { Link, Outlet } from "react-router-dom";
+import { useAppSelector } from "../app/hooks";
+import { selectUser } from "../features/userSlice";
+import { addLikes } from "../functions/AddLikes";
+import { Favorite } from "@mui/icons-material";
+import { db } from "../firebase";
+import {
+  collection,
+  CollectionReference,
+  doc,
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  getDoc,
+  onSnapshot,
+  QueryDocumentSnapshot,
+  QuerySnapshot,
+} from "firebase/firestore";
+
+interface Post {
+  avatarURL: string;
+  caption: string;
+  displayName: string;
+  id: string;
+  imageURL: string;
+  timestamp: Date | null;
+  uid: string;
+  username: string;
+}
+
+const PostComponent: React.VFC<{ postId: string; detail: boolean }> = memo(
+  (props) => {
+    const loginUid: string = useAppSelector(selectUser).uid;
+    const [post, setPost] = useState<Post>({
+      avatarURL: "",
+      caption: "",
+      displayName: "",
+      id: "",
+      imageURL: "",
+      timestamp: null,
+      uid: "",
+      username: "",
+    });
+    const [counts, setCounts] = useState<number>(0);
+    const [like, setLike] = useState<boolean>(false);
+    let isMounted: boolean = true;
+    const getPost: () => Promise<void> = async () => {
+      const postRef: DocumentReference<DocumentData> = doc(
+        db,
+        "posts",
+        props.postId
+      );
+      await getDoc(postRef).then((postSnap: DocumentSnapshot<DocumentData>) => {
+        if (postSnap.exists()) {
+          setPost({
+            avatarURL: postSnap.data().avatarURL,
+            caption: postSnap.data().caption,
+            displayName: postSnap.data().displayName,
+            id: postSnap.id,
+            imageURL: postSnap.data().imageURL,
+            timestamp: postSnap.data().timestamp.toDate(),
+            uid: postSnap.data().uid,
+            username: postSnap.data().username,
+          });
+        }
+      });
+      const likeUsersRef: CollectionReference<DocumentData> = collection(
+        db,
+        `posts/${props.postId}/likeUsers`
+      );
+      onSnapshot(likeUsersRef, (likeUsersSnap: QuerySnapshot<DocumentData>) => {
+        if (isMounted === true) {
+          setCounts(likeUsersSnap.size);
+          setLike(
+            likeUsersSnap.docs.find(
+              (likeUserSnap: QueryDocumentSnapshot<DocumentData>) => {
+                return likeUserSnap.data().uid === loginUid;
+              }
+            ) !== undefined
+          );
+        }
+      });
+    };
+
+    useEffect(() => {
+      if (isMounted === false) {
+        return;
+      }
+      getPost();
+      return () => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        isMounted = false;
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+      <div>
+        <div>
+          <p id="displayName">{post.displayName}</p>
+          <p id="timestamp">
+            {post.timestamp
+              ? `${post.timestamp.getFullYear()}年${
+                  post.timestamp!.getMonth() + 1
+                }月${post.timestamp!.getDate()}日`
+              : ""}
+          </p>
+          <Link to={`/${post.username}`}>
+            <img id="avatarURL" src={post.avatarURL} alt="アバター画像" />
+          </Link>
+        </div>
+        <div>
+          {props.detail ? (
+            <img id="image" src={post.imageURL} alt="投稿画像" />
+          ) : (
+            <Link to={`/${post.username}/${props.postId}`}>
+              <img id="image" src={post.imageURL} alt="投稿画像" />
+            </Link>
+          )}
+
+          <div color={like ? "red" : "white"}>
+            <Favorite
+              onClick={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+                event.preventDefault();
+                addLikes(props.postId, loginUid);
+              }}
+            />
+            {counts === null || counts === 0 ? (
+              <p id="likeCounts">{counts}</p>
+            ) : (
+              <Link to={`/${post.username}/${props.postId}/likeUsers`}>
+                <p id="likeCounts">{counts}</p>
+              </Link>
+            )}
+          </div>
+        </div>
+        <div>{props.detail && <p id="caption">{post.caption}</p>}</div>
+        <Outlet />
+      </div>
+    );
+  }
+);
+
+export default PostComponent;

--- a/src/functions/AddLikes.ts
+++ b/src/functions/AddLikes.ts
@@ -9,41 +9,39 @@ import {
   deleteDoc,
 } from "firebase/firestore";
 
-interface UserData {
-  avatarURL: string;
-  displayName: string;
-  uid: string;
-  username: string;
-  userType: "business" | "normal" | null;
-}
-
-export const addLikes: (postId: string, userData: UserData) => void = async (
+export const addLikes: (postId: string, loginUid: string) => void = async (
   postId,
-  userData
+  loginUid
 ) => {
+  const loginUserRef: DocumentReference<DocumentData> = doc(
+    db,
+    `users/${loginUid}`
+  );
   const likePostRef: DocumentReference<DocumentData> = doc(
     db,
-    `users/${userData.uid}/likePosts/${postId}`
+    `users/${loginUid}/likePosts/${postId}`
   );
   const likeUserRef: DocumentReference<DocumentData> = doc(
     db,
-    `posts/${postId}/likeUsers/${userData.uid}`
+    `posts/${postId}/likeUsers/${loginUid}`
   );
-  const likePostSnap: DocumentSnapshot<DocumentData> = await getDoc(
-    likePostRef
+  const loginUserSnap: DocumentSnapshot<DocumentData> = await getDoc(
+    loginUserRef
   );
   const likeUserSnap: DocumentSnapshot<DocumentData> = await getDoc(
     likeUserRef
   );
   if (!likeUserSnap.exists()) {
-    setDoc(likeUserRef, userData);
-    if (!likePostSnap.exists()) {
-      setDoc(likePostRef, { timestamp: new Date() });
-    }
-  } else if (likeUserSnap.exists()) {
+    setDoc(likeUserRef, {
+      avatarURL: loginUserSnap.data()!.avatarURL,
+      displayName: loginUserSnap.data()!.displayName,
+      uid: loginUid,
+      username: loginUserSnap.data()!.username,
+      userType: loginUserSnap.data()!.userType,
+    });
+    setDoc(likePostRef, { timestamp: new Date() });
+  } else {
     deleteDoc(likeUserRef);
-    if (likePostSnap.exists()) {
-      deleteDoc(likePostRef);
-    }
+    deleteDoc(likePostRef);
   }
 };

--- a/src/hooks/useLikeUsers.ts
+++ b/src/hooks/useLikeUsers.ts
@@ -11,22 +11,20 @@ import {
   FirestoreError,
 } from "firebase/firestore";
 
-interface UserData {
+interface User {
   avatarURL: string;
-  caption:string;
+  caption: string;
   displayName: string;
   uid: string;
   username: string;
   userType: "business" | "normal" | null;
 }
 
-export const useLikeUsers: (postId: string) => UserData[] = (
-  postId: string
-) => {
-  const [likeUsers, setLikeUsers] = useState<UserData[]>([]);
-
+export const useLikeUsers: (postId: string) => User[] = (postId: string) => {
+  const [likeUsers, setLikeUsers] = useState<User[]>([]);
+  let isMounted: boolean = postId !== undefined;
   const unsubscribe: (isMounted: boolean) => void = async (isMounted) => {
-    if (isMounted === false || postId === "") {
+    if (isMounted === false) {
       return;
     }
     const likeUsersRef: CollectionReference<DocumentData> = collection(
@@ -40,7 +38,7 @@ export const useLikeUsers: (postId: string) => UserData[] = (
         setLikeUsers(
           snapshots.docs.map(
             (snapshot: QueryDocumentSnapshot<DocumentData>) => {
-              const likeUser: UserData = {
+              const likeUser: User = {
                 avatarURL: snapshot.data().avatarURL,
                 caption: snapshot.data().caption,
                 displayName: snapshot.data().displayName,
@@ -62,9 +60,9 @@ export const useLikeUsers: (postId: string) => UserData[] = (
   };
 
   useEffect(() => {
-    let isMounted: boolean = true;
     unsubscribe(isMounted);
     return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       isMounted = false;
       unsubscribe(isMounted);
     };

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -26,6 +26,9 @@ export const usePosts = (username: string) => {
   const [posts, setPosts] = useState<Post[]>([]);
   let isMounted: boolean = true;
   const unsubscribe: () => void = async () => {
+    if (isMounted === false) {
+      return;
+    }
     const postsQuery: Query<DocumentData> = query(
       collection(db, "posts"),
       where("username", "==", username)
@@ -53,9 +56,7 @@ export const usePosts = (username: string) => {
             return changedPost;
           }
         );
-        if (isMounted === true) {
-          setPosts(unChangedPosts.concat(changedPosts));
-        }
+        setPosts(unChangedPosts.concat(changedPosts));
       },
       (error) => {
         console.error(error);

--- a/src/routes/Post.tsx
+++ b/src/routes/Post.tsx
@@ -1,166 +1,28 @@
-import React, { memo, useState, useEffect } from "react";
+import React, { memo } from "react";
 import {
-  Link,
-  Outlet,
   Params,
   useParams,
   useNavigate,
   NavigateFunction,
 } from "react-router-dom";
-import { useAppSelector } from "../app/hooks";
-import { selectUser, LoginUser } from "../features/userSlice";
-import { addLikes } from "../functions/AddLikes";
-import { Favorite } from "@mui/icons-material";
-import { db } from "../firebase";
-import {
-  collection,
-  CollectionReference,
-  doc,
-  DocumentData,
-  DocumentReference,
-  DocumentSnapshot,
-  getDoc,
-  onSnapshot,
-  QueryDocumentSnapshot,
-  QuerySnapshot,
-} from "firebase/firestore";
-
-interface User {
-  avatarURL: string;
-  displayName: string;
-  uid: string;
-  username: string;
-  userType: "business" | "normal" | null;
-}
-
-interface PostDoc {
-  avatarURL: string;
-  caption: string;
-  displayName: string;
-  id: string;
-  imageURL: string;
-  timestamp: Date | null;
-  uid: string;
-  username: string;
-}
+import PostComponent from "../components/PostComponent";
 
 const Post: React.VFC = memo(() => {
   const params: Readonly<Params<string>> = useParams();
-  const user: LoginUser = useAppSelector(selectUser);
-  const userData: User = {
-    avatarURL: user.avatarURL,
-    displayName: user.displayName,
-    uid: user.uid,
-    username: user.username,
-    userType: user.userType,
-  };
-  const [counts, setCounts] = useState<number | null>(null);
-  const [like, setLike] = useState<boolean>(false);
-  const [post, setPost] = useState<PostDoc>({
-    avatarURL: "",
-    caption: "",
-    displayName: "",
-    id: "",
-    imageURL: "",
-    timestamp: null,
-    uid: "",
-    username: "",
-  });
   const postId: string = params.docId!;
   const navigate: NavigateFunction = useNavigate();
 
-  const getPost = async (isMounted: boolean) => {
-    if (isMounted === false) {
-      return;
-    }
-    const postRef: DocumentReference<DocumentData> = doc(db, "posts", postId);
-    const postSnap: DocumentSnapshot<DocumentData> = await getDoc(postRef);
-    if (postSnap.exists()) {
-      setPost({
-        avatarURL: postSnap.data().avatarURL,
-        caption: postSnap.data().caption,
-        displayName: postSnap.data().displayName,
-        id: postSnap.id,
-        imageURL: postSnap.data().imageURL,
-        timestamp: postSnap.data().timestamp.toDate(),
-        uid: postSnap.data().uid,
-        username: postSnap.data().username,
-      });
-      const likeUsersRef: CollectionReference<DocumentData> = collection(
-        db,
-        `posts/${postSnap.id}/likeUsers`
-      );
-      onSnapshot(likeUsersRef, (likeUsersSnap: QuerySnapshot<DocumentData>) => {
-        setCounts(likeUsersSnap.size);
-        if (
-          likeUsersSnap.docs.find(
-            (likeUserSnap: QueryDocumentSnapshot<DocumentData>) => {
-              return likeUserSnap.data().uid === user.uid;
-            }
-          ) !== undefined
-        ) {
-          setLike(true);
-        } else {
-          setLike(false);
-        }
-      });
-    }
-  };
-
-  useEffect(() => {
-    let isMounted: boolean = true;
-    getPost(isMounted);
-    return () => {
-      isMounted = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <div>
-      <div>
-        <button
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            event.preventDefault();
-            navigate(-1);
-          }}
-        >
-          戻る
-        </button>
-        <p id="displayName">{post.displayName}</p>
-        <p id="timestamp">
-          {post.timestamp
-            ? `${post.timestamp.getFullYear()}年${
-                post.timestamp!.getMonth() + 1
-              }月${post.timestamp!.getDate()}日`
-            : ""}
-        </p>
-        <Link to={`/${post.username}`}>
-          <img id="avatarURL" src={post.avatarURL} alt="アバター画像" />
-        </Link>
-      </div>
-      <div>
-        <img id="image" src={post.imageURL} alt="投稿画像" />
-        <div color={like ? "red" : "white"}>
-          <Favorite
-            onClick={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-              event.preventDefault();
-              addLikes(postId, userData);
-            }}
-          />
-          {counts === null || counts === 0 ? (
-            <p id="likeCounts">{counts}</p>
-          ) : (
-            <Link to={`/${post.username}/${postId}/likeUsers`}>
-              <p id="likeCounts">{counts}</p>
-            </Link>
-          )}
-        </div>
-      </div>
-      <div>
-        <p id="caption">{post.caption}</p>
-      </div>
-      <Outlet />
+      <button
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          event.preventDefault();
+          navigate(-1);
+        }}
+      >
+        戻る
+      </button>
+      <PostComponent postId={postId} detail={true} />
     </div>
   );
 });

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -1,24 +1,19 @@
 import { Link, useSearchParams } from "react-router-dom";
 import { useSearch } from "../hooks/useSearch";
-import { Favorite } from "@mui/icons-material";
+import PostComponent from "../components/PostComponent";
+import { useEffect } from "react";
 
-interface PostData {
-  avatarURL: string;
-  caption: string;
-  displayName: string;
-  id: string;
-  imageURL: string;
-  timestamp: Date;
-  uid: string;
+interface Doc {
   username: string;
+  id: string;
+  timestamp: number;
 }
 
 const Search: React.VFC = () => {
   const tags: string[] = ["トマト", "米"];
   const [searchParams, setSearchParams] = useSearchParams();
-  const filter = searchParams.get("tag");
-  const posts: PostData[] = useSearch(filter);
-
+  const searchTag = searchParams.get("tag");
+  const docsArray: Doc[] = useSearch(searchTag);
   return (
     <div>
       {tags.map((tag: string) => {
@@ -44,34 +39,15 @@ const Search: React.VFC = () => {
           </button>
         );
       })}
-      {posts.length > 0 &&
-        posts.map((post: PostData) => {
-          return (
-            <div key={post.id}>
-              <div>
-                <p id="displayName">{post.displayName}</p>
-                <p id="timestamp">{`${post.timestamp.getFullYear()}年${
-                  post.timestamp.getMonth() + 1
-                }月${post.timestamp.getDate()}日`}</p>
-                <Link to={`/${post.username}`}>
-                  <img id="avatarURL" src={post.avatarURL} alt="アバター画像" />
-                </Link>
-              </div>
-              <div>
-                <Link to={`/${post.username}/${post.id}`}>
-                  <img src={post.imageURL} alt={post.caption} />
-                </Link>
-                <div>
-                  <Favorite />
-                  <p id="likeCounts">0</p>
-                </div>
-              </div>
-              <div>
-                <p id="caption">{post.caption}</p>
-              </div>
-            </div>
-          );
-        })}
+      {docsArray.map((document: Doc) => {
+        return (
+          <PostComponent
+            postId={document.id}
+            detail={false}
+            key={document.id}
+          />
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## Issue
#216 

## 変更した内容
src/components/PostComponent.tsx
- [x] 個々の投稿を表示するためのコンポーネントとしてPostComponent.tsxを作成しました
- [x] 引数として投稿したドキュメントのID（postId）と、詳細表示するかいなかのboolean値（detail）を設定しています
- [x] 「いいね」に関する表示はfirestoreのonSnapshotを使って実装しています
- [x] ユーザーのアバター画像をクリックすると、そのユーザーのプロフィール画面にリンクします
- [x] 投稿画像をクリックすると、その投稿の詳細画面にリンクします
- [x] 「いいね」数をクリックすると、「いいね」をつけたユーザーの一覧画面にリンクします

src/functions/AddLikes.ts
- [x] インターフェースUserDataを削除
- [x] likeUserSnapやlikePostSnapの有無で場合分けをしていたif文の箇所を削除

src/hooks/useLikeUsers.ts
- [x] インターフェースUseDataをUserに名称変更
- [x] useEffect内のisMountedの宣言をuseEffect外に移動

src/hooks/usePosts.ts
- [x] ステート変更前に設定していたisMountedの場合分けを関数unsubscribeの冒頭に移動

src/hooks/useSearch.ts
- [x] 検索にヒットしたユーザー１名分の投稿しか取得できない不具合が見つかったので、修正しました
- [x] 投稿ドキュメントのすべてのフィールドを取得するのではなく、投稿のIDのみ取得し、PostComponent.tsxを読み込んで投稿画像を表示する方法に切り替えました
- [x] 関数getUserDocsでは、引数のUIDを持つ投稿ドキュメントを取得し、username、id、timestampの３つの情報をリターンするはたらきをします
- [x] 関数getDocsArrayでは、useSearchフックスの引数であるsearchTagをキーとして、対象のユーザードキュメントを取得し、それぞれのユーザーが投稿した画像を一覧で取得するプロミスの配列を返します
- [x] 関数getDocsArrayの内部で、プロミスの結果をステートdocsArrayに反映する処理をおこないます。

src/routes/Post.tsx
- [x] Postコンポーネントが独自で投稿ドキュメントを取得し、画面表示するような方式を、ドキュメントIDを取得してからPostComponentを用いて画面表示する方法に変更しました

src/routes/Search.tsx
- [x] Searchコンポーネント内で投稿の表示内容を作成する方式から、PostComponentを用いて、投稿の表示内容を作成する方式に変更しました

## 動作の確認
- 検索タグを選択した際に、対応する画像一覧が画面上に表示されることを確認しました
- 画像一覧のいずれかの画像をクリックしたときに、投稿画像の詳細画面が表示されることを確認しました
- 画像一覧に「いいね」数が適切に表示されていることを確認しました
- 画像一覧の「いいね」ボタンをクリックすると、「いいね」機能が実行されることを確認しました
- 投稿画像の詳細画面に移行後、「いいね」ボタンをクリックしたときに、メモリリークしないことを確認しました
- コンソール内に<Link>タグに関するエラーが表示されないことを確認しました