### PR TITLE
👍 Feedドキュメントを登録する機能を実装しました

### DIFF
--- a/src/hooks/useBatch.ts
+++ b/src/hooks/useBatch.ts
@@ -79,20 +79,16 @@ export const useBatch: (
     const followersSnap: QuerySnapshot<DocumentData> = await getDocs(
       followersRef
     );
-    const followersArray: { uid: string; username: string }[] =
-      followersSnap.docs.map(
-        (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
-          return {
-            uid: followerSnap.id,
-            username: followerSnap.data().username,
-          };
-        }
-      );
+    const followersUidArray: string[] = followersSnap.docs.map(
+      (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
+        return followerSnap.id;
+      }
+    );
 
-    followersArray.forEach((follower: { uid: string; username: string }) => {
+    followersUidArray.forEach((followerUid: string) => {
       const feedRef: DocumentReference<DocumentData> = doc(
         db,
-        `users/${follower.uid}/feeds/${postId}`
+        `users/${followerUid}/feeds/${postId}`
       );
       batch.set(feedRef, postData);
     });

--- a/src/hooks/useBatch.ts
+++ b/src/hooks/useBatch.ts
@@ -17,6 +17,11 @@ import {
   WriteBatch,
   FieldValue,
   DocumentData,
+  collection,
+  CollectionReference,
+  getDocs,
+  QuerySnapshot,
+  QueryDocumentSnapshot,
 } from "firebase/firestore";
 
 interface Post {
@@ -47,19 +52,59 @@ export const useBatch: (
   postImage: string,
   caption: string
 ) => "wait" | "run" | "done" = (upload, postImage, caption) => {
-  const user: LoginUser = useAppSelector(selectUser);
-  const uid: string = user.uid;
-  const username: string = user.username;
-  const displayName: string = user.displayName;
-  const avatarURL: string = user.avatarURL;
   const [progress, setProgress] = useState<"wait" | "run" | "done">("wait");
+  const loginUser: LoginUser = useAppSelector(selectUser);
+  const batch: WriteBatch = writeBatch(db);
+
+  const setBatch: (downloadURL: string) => Promise<void> = async (
+    downloadURL
+  ) => {
+    const postId: string = getRandomString();
+    const postRef: DocumentReference<DocumentData> = doc(db, `posts/${postId}`);
+    // TODO >> フォローしているユーザーのUIDを参照するコードを作成する
+    const postData: Post = {
+      uid: loginUser.uid,
+      username: loginUser.username,
+      displayName: loginUser.displayName,
+      avatarURL: loginUser.avatarURL,
+      imageURL: downloadURL,
+      caption: caption,
+      timestamp: serverTimestamp(),
+    };
+    batch.set(postRef, postData);
+    const followersRef: CollectionReference<DocumentData> = collection(
+      db,
+      `users/${loginUser.uid}/followers`
+    );
+    const followersSnap: QuerySnapshot<DocumentData> = await getDocs(
+      followersRef
+    );
+    const followersArray: { uid: string; username: string }[] =
+      followersSnap.docs.map(
+        (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
+          return {
+            uid: followerSnap.id,
+            username: followerSnap.data().username,
+          };
+        }
+      );
+
+    followersArray.forEach((follower: { uid: string; username: string }) => {
+      const feedRef: DocumentReference<DocumentData> = doc(
+        db,
+        `users/${follower.uid}/feeds/${postId}`
+      );
+      batch.set(feedRef, postData);
+    });
+  };
+
   useEffect(() => {
     if (upload) {
       setProgress("run");
       const filename: string = getRandomString();
       const imageRef: StorageReference = ref(
         storage,
-        `posts/${uid}/${filename}`
+        `posts/${loginUser.uid}/${filename}`
       );
       const uploadPromise: Promise<UploadResult> = uploadString(
         imageRef,
@@ -69,26 +114,11 @@ export const useBatch: (
       uploadPromise
         .then(async () => {
           await getDownloadURL(imageRef).then(async (downloadURL: string) => {
-            const postId: string = getRandomString();
-            const postRef: DocumentReference<DocumentData> = doc(
-              db,
-              `posts/${postId}`
-            );
-            // TODO >> フォローしているユーザーのUIDを参照するコードを作成する
-            const postData: Post = {
-              uid: uid,
-              username: username,
-              displayName: displayName,
-              avatarURL: avatarURL,
-              imageURL: downloadURL,
-              caption: caption,
-              timestamp: serverTimestamp(),
-            };
-            const batch: WriteBatch = writeBatch(db);
-            batch.set(postRef, postData);
             // TODO >> フォローしているユーザーのFeedドキュメントにpostDataを書き込む処理を実装する
-            await batch.commit().then(() => {
-              setProgress("done");
+            setBatch(downloadURL).then(() => {
+              batch.commit().then(() => {
+                setProgress("done");
+              });
             });
           });
         })


### PR DESCRIPTION
## Issues
#222 

## 変更した内容
src/hooks/useBatch.ts
- [x] 投稿データのドキュメント登録に合わせて、フォロワーのfeedsコレクションにドキュメントを登録する機能を追加
- [x] フォロワーコレクションのスナップショットを取得し、フォロワーのUIDから構成される配列を作成する処理を追加
- [x] 各フォロワーのUIDごとにバッチ書き込みの予約をセットする機能を追加
- [x] バッチ書き込みの予約が完了したら、`batch.commit()`で書き込むよう設定

 ## 動作の確認
1.  tsugumonにログイン
2. +ボタンをクリックし、投稿データを送信
3. デベロッパーツールのコンソールを開く
 - [x] コンソールにエラーが発生していないことを確認
4. Firestoreのコンソールを確認
<img width="1440" alt="スクリーンショット 2022-08-19 16 22 49" src="https://user-images.githubusercontent.com/98272835/185566199-c21aa114-1ae2-4140-a842-ccdcbf965d03.png">

- [x] usersコレクションに新しくfeedsサブコレクションが作成されていることを確認
- [x] feedsサブコレクションに適切に投稿データのドキュメントが作成されていることを確認