### PR TITLE
🎨 プロフィール画面のスタイリングを行いました

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,8 +83,8 @@ const App: React.FC = () => {
           <Route path="/" element={<Navigate to="/home" />} />
         </Routes>
         <nav
-          className={`flex justify-around w-full h-20 fixed bottom-0 bg-slate-100 border-t border-slate-200 ${
-            scroll > 50 && "pd-4"
+          className={`flex justify-around w-full fixed bottom-0 bg-slate-100 border-t border-slate-200 ${
+            scroll > 50 ? "h-20" : "h-16"
           }`}
         >
           <button className="w-32">

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -67,18 +67,18 @@ const PostComponent: React.VFC<PostSummary> = memo((props) => {
 
   return (
     <div className="mb-12">
-      <div className="flex p-2 font-semibold">
-        <Link to={`/${props.username}`}>
+      <div className="p-2">
+        <Link className="flex" to={`/${props.username}`}>
           <img
             id="avatarURL"
             className="block w-12 h-12 rounded-full"
             src={props.avatarURL}
             alt="アバター画像"
           />
+          <p className="px-2 py-4 leading-4 font-semibold" id="displayName">
+            {props.displayName}
+          </p>
         </Link>
-        <p className="px-2 py-4 leading-4" id="displayName">
-          {props.displayName}
-        </p>
       </div>
       <p className="-mt-4 mr-4 text-right" id="timestamp">
         {props.timestamp

--- a/src/routes/Auth.tsx
+++ b/src/routes/Auth.tsx
@@ -65,7 +65,7 @@ const UserAuthentication = () => {
               メールアドレス
             </label>
             <input
-              className="block w-80 h-8 px-4 rounded-md outline-none bg-slate-200"
+              className="block w-10/12 h-8 px-4 rounded-md outline-none bg-slate-200"
               name="textbox"
               type="email"
               id="email"
@@ -84,7 +84,7 @@ const UserAuthentication = () => {
             </label>
             <div className="flex">
               <input
-                className="block w-80 h-8 px-4 rounded-md outline-none bg-slate-200"
+                className="block w-10/12 h-8 px-4 rounded-md outline-none bg-slate-200"
                 type={showPassword ? "text" : "password"}
                 id="password"
                 data-testid="password"

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useState, useEffect } from "react";
 import {
   Link,
   Outlet,
@@ -11,6 +11,10 @@ import { useProfile } from "../hooks/useProfile";
 import { usePosts } from "../hooks/usePosts";
 import PostComponent from "../components/PostComponent";
 import { addFollower } from "../functions/AddFollower";
+import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewRounded";
+import MailOutlined from "@mui/icons-material/MailOutlined";
+import PhotoLibraryOutlined from "@mui/icons-material/PhotoLibraryOutlined";
+import PersonAddOutlined from "@mui/icons-material/PersonAddOutlined";
 
 interface Post {
   avatarURL: string;
@@ -45,104 +49,154 @@ const Profile: React.VFC = memo(() => {
     loginUser,
   } = useProfile(username)!;
   const posts: Post[] = usePosts(username);
+  const [scroll, setScroll] = useState<number>(0);
+  const [tab, setTab] = useState<"album" | "wanted">("album");
+
+  useEffect(() => {
+    window.addEventListener("scroll", () => {
+      setScroll(window.scrollY);
+      console.log(scroll);
+    });
+    return () => {
+      window.removeEventListener("scroll", () => {
+        if (process.env.NODE_ENV === "development") {
+          console.log("イベントリスナーをリセットしました。");
+        }
+      });
+    };
+  });
 
   return (
     <div>
-      <div id="top">
-        <button
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            event.preventDefault();
-            navigate(-1);
+      <div>
+        <div
+          className="flex fixed top-0 w-screen h-12"
+          style={{
+            backgroundColor: `rgba(241,245,249,${scroll / 144} )`,
           }}
         >
-          戻る
-        </button>
-        <img id="background" src={user.backgroundURL} alt="背景画像" />
-        <img
-          id="avatar"
-          src={
-            user.avatarURL
-              ? user.avatarURL
-              : `${process.env.PUBLIC_URL}/noAvatar.png`
-          }
-          alt="アバター画像"
-        />
-        {loginUser.uid === user.uid ? (
-          <Link to="/setting">
-            <p>プロフィールを編集する</p>
-          </Link>
-        ) : (
           <button
+            className={`p-2 ${
+              scroll > 144 ? "text-slate-500" : "text-slate-100"
+            }`}
             onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
               event.preventDefault();
-              const following: FollowUser = {
-                avatarURL: user.avatarURL,
-                displayName: user.displayName,
-                introduction: user.introduction,
-                uid: user.uid,
-                username: user.username,
-                userType: user.userType,
-              };
-              const follower: FollowUser = {
-                avatarURL: loginUser.avatarURL,
-                displayName: loginUser.displayName,
-                introduction: loginUser.introduction,
-                uid: loginUser.uid,
-                username: loginUser.username,
-                userType: loginUser.userType,
-              };
-              addFollower(following, follower);
+              navigate(-1);
             }}
           >
-            {isFollowing ? "フォロー解除" : "フォローする"}
+            <ArrowBackRounded />
           </button>
-        )}
-        <p id="displayName">{user.displayName}</p>
+        </div>
+        <div className="w-auto h-auto">
+          <img
+            className="object-cover w-screen h-48"
+            id="background"
+            src={user.backgroundURL}
+            alt="背景画像"
+          />
+        </div>
+        <div className="flex justify-between">
+          <img
+            className="w-20 h-20 ml-4 -mt-8 border-4 border-slate-100 rounded-full"
+            id="avatar"
+            src={
+              user.avatarURL
+                ? user.avatarURL
+                : `${process.env.PUBLIC_URL}/noAvatar.png`
+            }
+            alt="アバター画像"
+          />
+          <div className="flex justify-between w-40 p-2 mr-4">
+            <button className="flex justify-center items-center w-8 h-8 rounded-full border border-emerald-500 text-emerald-500 hover:border-none hover:text-slate-100 hover:bg-emerald-500">
+              <MailOutlined />
+            </button>
+            {loginUser.uid === user.uid ? (
+              <Link to="/setting">
+                <div className="flex justify-center">
+                  <button className="w-24 h-8 font-bold rounded-full border border-emerald-500 text-emerald-500 hover:border-none hover:text-slate-100 hover:bg-emerald-500 ">
+                    編集する
+                  </button>
+                </div>
+              </Link>
+            ) : (
+              <button
+                className="border text-sm"
+                onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                  event.preventDefault();
+                  const following: FollowUser = {
+                    avatarURL: user.avatarURL,
+                    displayName: user.displayName,
+                    introduction: user.introduction,
+                    uid: user.uid,
+                    username: user.username,
+                    userType: user.userType,
+                  };
+                  const follower: FollowUser = {
+                    avatarURL: loginUser.avatarURL,
+                    displayName: loginUser.displayName,
+                    introduction: loginUser.introduction,
+                    uid: loginUser.uid,
+                    username: loginUser.username,
+                    userType: loginUser.userType,
+                  };
+                  addFollower(following, follower);
+                }}
+              >
+                {isFollowing ? "フォロー中" : "フォローする"}
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="pl-4 pr-2 py-2">
+          <p className="width-screen text-xl font-semibold ">
+            {user.displayName}
+          </p>
+          <p className="width-screen text-sm text-slate-500">{user.username}</p>
+        </div>
+        <div className="flex px-4">
+          <div>
+            {followersCount > 0 ? (
+              <Link className="flex" to={`/${username}/followers`}>
+                <p className="text-sm">フォロワー</p>
+                <p className="w-12 ml-2 text-sm font-bold">{followersCount}</p>
+              </Link>
+            ) : (
+              <div className="flex">
+                <p className="text-sm">フォロワー</p>
+                <p className="w-12 ml-2 text-sm font-bold">{followersCount}</p>
+              </div>
+            )}
+          </div>
+          <div className="flex">
+            {followingsCount > 0 ? (
+              <Link className="flex" to={`/${username}/followings`}>
+                <p className="text-sm">フォロー中</p>
+                <p className="w-12 ml-2 text-sm font-bold">{followingsCount}</p>
+              </Link>
+            ) : (
+              <div className="flex">
+                <p className="text-sm">フォロー中</p>
+                <p className="w-12 ml-2 text-sm font-bold">{followingsCount}</p>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
-      <div id="profile">
-        <p>紹介文</p>
-        <p>{user.introduction}</p>
-        <div id="tags">
-          {user.cropsTags.map((cropsTag) => {
-            return <p key={cropsTag}>{cropsTag}</p>;
-          })}
-        </div>
-        <div id="followerCounts">
-          {followersCount > 0 ? (
-            <Link to={`/${username}/followers`}>
-              <p>フォロワー</p>
-              <p>{followersCount}</p>
-            </Link>
-          ) : (
-            <>
-              <p>フォロワー</p>
-              <p>{followersCount}</p>
-            </>
-          )}
-        </div>
-        <div id="followingCounts">
-          <p>フォロー中</p>
-          {followingsCount > 0 ? (
-            <Link to={`/${username}/followings`}>
-              <p>{followingsCount}</p>
-            </Link>
-          ) : (
-            <p>{followingsCount}</p>
-          )}
-        </div>
+      <div className="p-4" id="profile">
+        <p className="mb-4">{user.introduction}</p>
         {user.userType === "business" ? (
           <div id="business">
             <div id="owner">
-              <p>事業主</p>
-              <p>{option.owner}</p>
+              <p className="text-sm text-slate-500">事業主</p>
+              <p className="ml-2">{option.owner}</p>
             </div>
             <div id="typeOfWork">
-              <p>職種</p>
-              <p>{option.typeOfWork}</p>
+              <p className="text-sm text-slate-500">職種</p>
+              <p className="ml-2">{option.typeOfWork}</p>
             </div>
             <div id="address">
-              <p>住所</p>
-              <p>{option.address}</p>
+              <p className="text-sm text-slate-500">住所</p>
+              <p className="ml-2">{option.address}</p>
             </div>
           </div>
         ) : (
@@ -157,24 +211,58 @@ const Profile: React.VFC = memo(() => {
           </div>
         )}
       </div>
-      <div>
-        {posts.map((post: Post) => {
-          return (
-            <PostComponent
-              key={post.id}
-              avatarURL={post.avatarURL}
-              caption={post.caption}
-              displayName={post.displayName}
-              id={post.id}
-              imageURL={post.imageURL}
-              timestamp={post.timestamp}
-              uid={post.uid}
-              username={post.username}
-              detail={false}
-            />
-          );
-        })}
-      </div>
+      <nav className="flex w-screen h-12">
+        <button
+          className={`flex items-center justify-center w-1/2 ${
+            tab === "album"
+              ? "border-b-4 box-border border-emerald-500 text-emerald-500 "
+              : "border-b-4 box-border border-slate-100 text-slate-500"
+          }`}
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+            setTab("album");
+          }}
+        >
+          <PhotoLibraryOutlined />
+          <p className="h-4 ml-2 text-sm font-bold">過去の投稿</p>
+        </button>
+        <button
+          className={`flex items-center justify-center w-1/2 ${
+            tab === "wanted"
+              ? "border-b-4 box-border border-emerald-500 text-emerald-500"
+              : "border-b-4 box-border border-slate-100 text-slate-500"
+          }`}
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+            setTab("wanted");
+          }}
+        >
+          <PersonAddOutlined />
+          <p className="h-4 ml-2 text-sm font-bold">募集中</p>
+        </button>
+      </nav>
+      {tab === "album" ? (
+        <div className="mt-4">
+          {posts.map((post: Post) => {
+            return (
+              <PostComponent
+                key={post.id}
+                avatarURL={post.avatarURL}
+                caption={post.caption}
+                displayName={post.displayName}
+                id={post.id}
+                imageURL={post.imageURL}
+                timestamp={post.timestamp}
+                uid={post.uid}
+                username={post.username}
+                detail={false}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <p>募集中！</p>
+      )}
       <Outlet />
     </div>
   );


### PR DESCRIPTION
## Issue
#229 

## 変更した内容
src/App.tsx
- [x] 前回のイシューで実装した、タブバー表示の高さをスクロール量に応じて変化させる機能に不具合が見つかったため、修正しました

src/components/PostComponent.tsx
- [x] ユーザーの表示名をクリックするとリンク先へ遷移するよう、`<p>`タグの位置を調整しました

src/routes/Auth.tsx
- [x] レスポンシブ対応ができるよう、メールアドレスとパスワードの入力欄の幅を指定しました

src/routes/Profile.tsx
- [x] Y軸にスクロールした量と選択したタブを記録するステートを追加しました
- [x] useEffectの処理でスクロールした量をステートに記録するようにしました
- [x] スクロール量に応じて、ヘッダーの背景色の透明度が変化するようにしました
- [x] スクロール量が基準値を上回ったら「戻る」ボタンの文字色を変化させるよう設定しました
- [x] ユーザーのプロフィール表示順を少し変更しました

## 動作の確認
<img width="1436" alt="スクリーンショット 2022-08-28 22 37 48" src="https://user-images.githubusercontent.com/98272835/187076738-26140b52-5ae3-46f4-bd9d-ebc4193d76c3.png">

デベロッパーツールのコンソールにエラーが表示されないことを確認しました