### PR TITLE
✨ プロフィール編集画面で生年月日をプルダウンで入力できるようにしました

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface Props {
+  message: string;
+  yes: string;
+  no: string;
+}
+
+const Modal: React.VFC<Props> = (props: Props) => {
+  return (
+    <div>
+      <p>{props.message}</p>
+      <div>
+        <button
+          onClick={(event) => {
+            event.preventDefault();
+            console.log("しょうきょしました")
+          }}
+        >
+          {props.yes}
+        </button>
+        <button>{props.no}</button>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import Post from "./routes/PostDetail";
 import LikeUsers from "./routes/LikeUsers";
 import Comments from "./routes/Comments";
 import Profile from "./routes/Profile";
-import Setting from "./routes/Setting";
+import NewSetting from "./routes/NewSetting";
 import SignUp from "./routes/SignUp";
 import Upload from "./routes/Upload";
 import { store } from "./app/store";
@@ -33,7 +33,7 @@ ReactDOM.render(
           <Route path="/login" element={<Login />} />
           <Route path="/upload" element={<Upload />} />
           <Route path="/signup" element={<SignUp />} />
-          <Route path="/setting" element={<Setting />} />
+          <Route path="/setting" element={<NewSetting />} />
           <Route path="/:username" element={<Profile />} />
           <Route path="/:username/:docId" element={<Post />} />
           <Route path="/:username/:docId/likeUsers" element={<LikeUsers />} />

--- a/src/routes/NewSetting.tsx
+++ b/src/routes/NewSetting.tsx
@@ -1,0 +1,222 @@
+import React, { useRef, useState, useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "../app/hooks";
+import { selectUser, LoginUser, setUserProfile } from "../features/userSlice";
+import { NavigateFunction, useNavigate } from "react-router-dom";
+import { auth, db, storage } from "../firebase";
+import { updateProfile } from "firebase/auth";
+import {
+  collection,
+  doc,
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  getDoc,
+  getDocs,
+  query,
+  Query,
+  QuerySnapshot,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+import {
+  deleteObject,
+  getDownloadURL,
+  ref,
+  StorageReference,
+  uploadString,
+} from "firebase/storage";
+import { resizeImage } from "../functions/ResizeImage";
+import { checkUsername } from "../functions/CheckUsername";
+import CloseRounded from "@mui/icons-material/CloseRounded";
+
+const NewSetting = () => {
+  const [avatarImage, setAvatarImage] = useState<string>("");
+  const [backgroundImage, setBackgroundImage] = useState<string>("");
+  const [backgroundURL, setBackgroundURL] = useState<string>("");
+  const birthdayYear = useRef<HTMLSelectElement>(null);
+  const birthdayMonth = useRef<HTMLSelectElement>(null);
+  const [dates, setDates] = useState<number[]>([]);
+  const introduction = useRef<HTMLTextAreaElement>(null);
+  const loginUser: LoginUser = useAppSelector(selectUser);
+  const navigate: NavigateFunction = useNavigate();
+  let isMounted: boolean = true;
+
+  let years: number[] = [];
+  const thisYear: number = new Date().getFullYear();
+  for (let i = thisYear; i >= thisYear - 100; i--) {
+    years.push(i);
+  }
+  const months: number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+  const getDates: () => void = () => {
+    const year = Number(birthdayYear.current!.value);
+    const isLeapYear: boolean =
+      (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    const datesOfFebruary = isLeapYear ? 29 : 28;
+    const datesOfYear: number[] = [
+      31,
+      datesOfFebruary,
+      31,
+      30,
+      31,
+      30,
+      31,
+      31,
+      30,
+      31,
+      30,
+      31,
+    ];
+    const month: number = Number(birthdayMonth.current!.value);
+    const dateArray: number[] = [];
+    const datesOfMonth: number = datesOfYear[month - 1];
+    for (let i = 1; i <= datesOfMonth; i++) {
+      dateArray.push(i);
+    }
+    setDates(dateArray);
+  };
+
+  const onChangeImageHandler: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    imageFor: "avatar" | "background"
+  ) => void = (event, imageFor) => {
+    const file: File = event.target.files![0];
+    const reader: FileReader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = async () => {
+      const processed: string = await resizeImage(reader.result as string);
+      if (imageFor === "avatar") {
+        setAvatarImage(processed);
+      } else if (imageFor === "background") {
+        setBackgroundImage(processed);
+      } else {
+        return;
+      }
+    };
+    reader.onerror = () => {
+      if (process.env.NODE_ENV === "development") {
+        console.log(reader.error);
+      }
+    };
+  };
+  const handleSubmit = () => {
+    console.log(`紹介文:${introduction.current?.value}\nアバター画像`);
+  };
+
+  const loginUserRef: DocumentReference<DocumentData> = doc(
+    db,
+    "users",
+    `${loginUser.uid}`
+  );
+
+  useEffect(() => {
+    if (isMounted === false) {
+      return;
+    }
+    getDates();
+    getDoc(loginUserRef).then(
+      (userSnapshot: DocumentSnapshot<DocumentData>) => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        setBackgroundURL(userSnapshot.data()!.backgroundURL);
+        setBackgroundImage(userSnapshot.data()!.backgroundURL);
+      }
+    );
+  }, []);
+
+  return (
+    <div>
+      <button
+        onClick={(event) => {
+          event.preventDefault();
+          navigate(-1);
+        }}
+      >
+        戻る
+      </button>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            event.preventDefault();
+            onChangeImageHandler(event, "avatar");
+          }}
+        />
+        <img
+          src={
+            loginUser.avatarURL
+              ? avatarImage
+                ? avatarImage
+                : loginUser.avatarURL
+              : `${process.env.PUBLIC_URL}/noAvatar.png}`
+          }
+          alt="アバター画像"
+        />
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            event.preventDefault();
+            onChangeImageHandler(event, "background");
+          }}
+        />
+        <img
+          src={
+            backgroundImage !== ""
+              ? backgroundImage
+              : `${process.env.PUBLIC_URL}/noPhoto.png`
+          }
+          alt="背景画像"
+        />
+        <button
+          onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            event.preventDefault();
+            backgroundImage === backgroundURL
+              ? setBackgroundImage("")
+              : setBackgroundImage(backgroundURL);
+          }}
+        >
+          <CloseRounded />
+        </button>
+        <textarea ref={introduction} defaultValue={loginUser.introduction} />
+        <input type="submit" value="登録する" />
+        {loginUser.userType === "normal" && (
+          <div>
+            <select ref={birthdayYear}>
+              {years.map((year: number) => {
+                return <option key={year}>{year}</option>;
+              })}
+            </select>
+            <label>年</label>
+            <select
+              ref={birthdayMonth}
+              onChange={(event) => {
+                event.preventDefault();
+                getDates();
+              }}
+            >
+              {months.map((month: number) => {
+                return <option key={month}>{month}</option>;
+              })}
+            </select>
+            <label>月</label>
+            <select>
+              {dates.map((date: number) => {
+                return <option key={date}>{date}</option>;
+              })}
+            </select>
+            <label>日</label>
+          </div>
+        )}
+      </form>
+    </div>
+  );
+};
+
+export default NewSetting;

--- a/src/routes/NewSetting.tsx
+++ b/src/routes/NewSetting.tsx
@@ -36,10 +36,17 @@ const NewSetting = () => {
   const [backgroundURL, setBackgroundURL] = useState<string>("");
   const birthdayYear = useRef<HTMLSelectElement>(null);
   const birthdayMonth = useRef<HTMLSelectElement>(null);
+  const birthday = useRef<HTMLSelectElement>(null);
   const [dates, setDates] = useState<number[]>([]);
+  const displayName = useRef<HTMLInputElement>(null);
   const introduction = useRef<HTMLTextAreaElement>(null);
   const loginUser: LoginUser = useAppSelector(selectUser);
+  const skill1 = useRef<HTMLInputElement>(null);
+  const skill2 = useRef<HTMLInputElement>(null);
+  const skill3 = useRef<HTMLInputElement>(null);
+
   const navigate: NavigateFunction = useNavigate();
+
   let isMounted: boolean = true;
 
   let years: number[] = [];
@@ -184,6 +191,11 @@ const NewSetting = () => {
         >
           <CloseRounded />
         </button>
+        <input
+          type="text"
+          ref={displayName}
+          defaultValue={loginUser.displayName}
+        />
         <textarea ref={introduction} defaultValue={loginUser.introduction} />
         <input type="submit" value="登録する" />
         {loginUser.userType === "normal" && (
@@ -206,12 +218,13 @@ const NewSetting = () => {
               })}
             </select>
             <label>月</label>
-            <select>
+            <select ref={birthday}>
               {dates.map((date: number) => {
                 return <option key={date}>{date}</option>;
               })}
             </select>
             <label>日</label>
+            <input type="text" ref={skill1} />
           </div>
         )}
       </form>

--- a/src/routes/NewSetting.tsx
+++ b/src/routes/NewSetting.tsx
@@ -26,6 +26,7 @@ import {
   StorageReference,
   uploadString,
 } from "firebase/storage";
+import Modal from "../components/Modal";
 import { resizeImage } from "../functions/ResizeImage";
 import { checkUsername } from "../functions/CheckUsername";
 import CloseRounded from "@mui/icons-material/CloseRounded";
@@ -110,6 +111,9 @@ const NewSetting = () => {
   const handleSubmit = () => {
     console.log(`紹介文:${introduction.current?.value}\nアバター画像`);
   };
+  const eraseImage: (image: "avatar" | "background") => void = (image) => {
+    console.log(`${image}を削除しました。`);
+  };
 
   const loginUserRef: DocumentReference<DocumentData> = doc(
     db,
@@ -188,6 +192,7 @@ const NewSetting = () => {
               ? setBackgroundImage("")
               : setBackgroundImage(backgroundURL);
           }}
+          disabled={backgroundImage === ""}
         >
           <CloseRounded />
         </button>
@@ -200,7 +205,13 @@ const NewSetting = () => {
         <input type="submit" value="登録する" />
         {loginUser.userType === "normal" && (
           <div>
-            <select ref={birthdayYear}>
+            <select
+              ref={birthdayYear}
+              onChange={(event) => {
+                event.preventDefault();
+                getDates();
+              }}
+            >
               {years.map((year: number) => {
                 return <option key={year}>{year}</option>;
               })}


### PR DESCRIPTION
## Issue
#244 

## 変更した内容
src/index.tsx
- [x] 編集画面を再構成するため、新しく`NewSetting`というコンポーネントを作成

src/routes/NewSetting.tsx
- [x] アバター画像や背景画像、日付の表記など、再レンダリングの必要性がある項目以外は、ステートではなく、`useRef()`を活用して値を保存するように変更した
- [x] 生年月日を設定するために、`useRef()`の参照をおこなう`birthdayYear`、`birthdayMonth`、`birthday`という３つの変数を作成した
- [x] ステート`dates`を作成し、`birthdayMonth`の値に対応して、再レンダリングされるよう設定した
- [x] `birthdayMonth`の値に対応して、ステート`dates`を変更する関数`getDates()`を作成した



## 動作の確認
1. Normalユーザーアカウントでログイン
2. プロフィール編集画面に移行
3. 生年月日をプルダウンで選択できることを確認
4. 誕生月を２月に合わせて、日数が自動で「２８」日分、表示されることを確認
<img width="1440" alt="スクリーンショット 2022-09-15 11 41 31" src="https://user-images.githubusercontent.com/98272835/190302375-6344920e-5381-42ac-a0e1-f6e6209dda17.png">

5. 誕生年を閏年に合わせて、２月の日数が自動で「２９」日分、表示されることを確認
<img width="1440" alt="スクリーンショット 2022-09-15 11 48 28" src="https://user-images.githubusercontent.com/98272835/190302532-c58abe7f-a815-43ff-9484-492a8a04a6dd.png">

