### PR TITLE
👍 useDemoで生年月日をDateオブジェクトの形で登録できるようにしました

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -144,7 +144,7 @@
       "option": {
         "achademicHistory": "福岡大学 経済学部",
         "address": "福岡市城南区西片江2-17-6",
-        "birthdate": "2011-11-10",
+        "birthdate": "2011,11,10",
         "owner": "",
         "skill1": "日本農業検定3級",
         "skill2": "普通自動車運転免許",
@@ -166,7 +166,7 @@
       "option": {
         "achademicHistory": "熊本大学 経済学部",
         "address": "熊本県熊本市西区春日３丁目",
-        "birthdate": "1978-6-23",
+        "birthdate": "1978,6,23",
         "owner": "",
         "skill1": "普通自動車運転免許",
         "skill2": "簿記3級",
@@ -217,14 +217,14 @@
       ],
       "option": {
         "achademicHistory": "",
-        "address": "熊本県八代市本町119番地",
+        "address": "熊本県八代市本町220番地",
         "birthdate": "",
-        "owner": "継田 譲司",
+        "owner": "町田 圭一",
         "skill1": "",
         "skill2": "",
         "skill3": "",
-        "tags": "#米 #稲作 #定年後 #専業農家 #熊本",
-        "typeOfWork": "農家",
+        "tags": "#ガラス #熊本",
+        "typeOfWork": "製造業",
         "workHistory": ""
       }
     }

--- a/src/hooks/useDemo.ts
+++ b/src/hooks/useDemo.ts
@@ -134,10 +134,13 @@ export const useDemo: (uploadDemo: boolean) => "wait" | "run" | "done" = (
               db,
               `option/${uid}/`
             );
+            const birthdate: Date | null = fetchedUser.option.birthdate
+              ? new Date(Date.parse(fetchedUser.option.birthdate))
+              : null;
             await setDoc(optionRef, {
               achademicHistory: fetchedUser.option.achademicHistory,
               address: fetchedUser.option.address,
-              birthdate: fetchedUser.option.birthdate,
+              birthdate: birthdate,
               owner: fetchedUser.option.owner,
               skill1: fetchedUser.option.skill1,
               skill2: fetchedUser.option.skill2,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -28,7 +28,7 @@ interface User {
 
 interface Option {
   address: string;
-  birthdate: string;
+  birthdate: Date | null;
   owner: string;
   skill: string;
   typeOfWork: string;
@@ -54,7 +54,7 @@ export const useProfile: (username: string) => {
   });
   const [option, setOption] = useState<Option>({
     address: "",
-    birthdate: "",
+    birthdate: null,
     owner: "",
     skill: "",
     typeOfWork: "",
@@ -94,7 +94,7 @@ export const useProfile: (username: string) => {
     const optionSnap: QuerySnapshot<DocumentData> = await getDocs(optionQuery);
     setOption({
       address: optionSnap.docs[0].data().address,
-      birthdate: optionSnap.docs[0].data().birthdate,
+      birthdate: optionSnap.docs[0].data().birthdate.toDate(),
       owner: optionSnap.docs[0].data().owner,
       skill: optionSnap.docs[0].data().skill,
       typeOfWork: optionSnap.docs[0].data().typeOfWork,

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -215,7 +215,13 @@ const Profile: React.VFC = memo(() => {
           <div id="normal">
             <div id="birthdate">
               <p>生年月日</p>
-              <p>{option.birthdate}</p>
+              <p>
+                {option.birthdate
+                  ? `${option.birthdate.getFullYear()}年${
+                      option.birthdate.getMonth() + 1
+                    }月${option.birthdate.getDate()}日`
+                  : ""}
+              </p>
             </div>
             <div id="skill">
               <p>{option.skill}</p>


### PR DESCRIPTION
## Issue
#255 

## 変更した内容

**public/data.json**
- [x] birthdateの表記をカンマ区切りに変更

**src/hooks/useDemo.ts**
- [x] birthdateの情報をDateオブジェクト、もしくはnullで登録できるように変更しました

**src/hooks/useProfile.ts**
- [x] optionコレクションから取得するbirthdateフィールドの情報をDateオブジェクトに変更する処理を追加しました

**src/routes/Profile.tsx**
- [x] ユーザーの生年月日を画面に表示できるようにしました

## 動作の確認
- デモデータの登録機能がエラーなく実行されることを確認しました
- Normalユーザーでログインし、生年月日の表示が適正におこなわれていることを確認しました