### PR TITLE
👍 Normalユーザーの生年月日をFirestoreに登録できるようにしました

### DIFF
--- a/src/routes/SettingNormal.tsx
+++ b/src/routes/SettingNormal.tsx
@@ -107,6 +107,15 @@ const SettingNormal = () => {
       skill1.current!.value = optionSnap.data()!.skill1;
       skill2.current!.value = optionSnap.data()!.skill2;
       skill3.current!.value = optionSnap.data()!.skill3;
+      const birthdate: Date | null = optionSnap.data()!.birthdate
+        ? optionSnap.data()!.birthdate.toDate()
+        : null;
+      if (birthdate) {
+        birthdayYear.current!.value = birthdate.getFullYear().toString();
+        birthdayMonth.current!.value = (birthdate.getMonth() + 1).toString();
+        getDates();
+        birthday.current!.value = birthdate.getDate().toString();
+      }
     });
     setIsFetched(true);
   };
@@ -186,6 +195,16 @@ const SettingNormal = () => {
     } else {
       backgroundURL = loginUser.backgroundURL;
     }
+
+    let birthdate: Date = new Date(
+      parseInt(birthdayYear.current!.value),
+      // NOTE >> プルダウンでは1月スタートになっているため、
+      //         birthdayMonth.currentの値を-1してあげる必要が
+      //         あります
+      parseInt(birthdayMonth.current!.value) - 1,
+      parseInt(birthday.current!.value)
+    );
+
     dispatch(
       setUserProfile({
         avatarURL: avatarURL,
@@ -203,6 +222,7 @@ const SettingNormal = () => {
     });
     updateDoc(optionRef, {
       address: address.current!.value,
+      birthdate: birthdate,
     });
     updateProfile(auth.currentUser!, {
       displayName: displayName,

--- a/src/routes/SettingNormal.tsx
+++ b/src/routes/SettingNormal.tsx
@@ -107,14 +107,14 @@ const SettingNormal = () => {
       skill1.current!.value = optionSnap.data()!.skill1;
       skill2.current!.value = optionSnap.data()!.skill2;
       skill3.current!.value = optionSnap.data()!.skill3;
-      const birthdate: Date | null = optionSnap.data()!.birthdate
+      const fetchedDate: Date | null = optionSnap.data()!.birthdate
         ? optionSnap.data()!.birthdate.toDate()
         : null;
-      if (birthdate) {
-        birthdayYear.current!.value = birthdate.getFullYear().toString();
-        birthdayMonth.current!.value = (birthdate.getMonth() + 1).toString();
+      if (fetchedDate) {
+        birthdayYear.current!.value = fetchedDate.getFullYear().toString();
+        birthdayMonth.current!.value = (fetchedDate.getMonth() + 1).toString();
         getDates();
-        birthday.current!.value = birthdate.getDate().toString();
+        birthday.current!.value = fetchedDate.getDate().toString();
       }
     });
     setIsFetched(true);
@@ -196,7 +196,7 @@ const SettingNormal = () => {
       backgroundURL = loginUser.backgroundURL;
     }
 
-    let birthdate: Date = new Date(
+    const birthdate: Date = new Date(
       parseInt(birthdayYear.current!.value),
       // NOTE >> プルダウンでは1月スタートになっているため、
       //         birthdayMonth.currentの値を-1してあげる必要が


### PR DESCRIPTION
## Issue
#259 

## 変更した内容
**src/routes/SettingNormal.tsx**
- [x] FIrestoreのドキュメントから誕生年、誕生月、誕生日の情報を`birthdayYear`、`birthdayMonth`、`birthday`に読み込む処理を追加しました
- [x] `birethdayYear.cuurent.value`と`birthdayMonth.current.value - 1`と、`birthdate.current.value`の文字列からDateオブジェクトを作成し、Firestoreに登録する処理を追加しました

## 動作の確認
- Normalユーザーでログインし、プロフィール編集画面を開いた際、登録されている生年月日の情報が初期値として表示されることを確認しました
- Normalユーザーのプロフィール編集画面で、生年月日の情報を修正した際、Firestoreに問題なく登録されることを確認しました