### PR TITLE
✨ Firestoreに登録されているメッセージの閲覧機能を追加しました

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect } from "react";
+import { db } from "../firebase";
+import {
+  collection,
+  DocumentData,
+  FirestoreError,
+  onSnapshot,
+  orderBy,
+  Query,
+  query,
+  QueryDocumentSnapshot,
+  QuerySnapshot,
+} from "firebase/firestore";
+import { Message } from "../interfaces/Message";
+
+export const useMessages: (roomId: string) => Message[] = (roomId) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  let isMounted: boolean = roomId !== undefined;
+  const unsubscribe: () => void = async () => {
+    const messagesQuery: Query<DocumentData> = query(
+      collection(db, `rooms/${roomId}/messages`),
+      orderBy("timestamp", "asc")
+    );
+
+    onSnapshot(
+      messagesQuery,
+      (messagesSnap: QuerySnapshot<DocumentData>) => {
+        if (isMounted === false) {
+          return;
+        }
+        const uploadedMessages: Message[] = messagesSnap.docs.map(
+          (messageSnap: QueryDocumentSnapshot) => {
+            const value: DocumentData = messageSnap.data();
+            const message: Message = {
+              messageId: messageSnap.id,
+              senderAvatarURL: value.senderavatarURL,
+              message: value.message,
+              senderUID: value.senderUID,
+              receiverUID: value.receiverUID,
+              timestamp: value.timestamp && value.timestamp.toDate(),
+            };
+            return message;
+          }
+        );
+        setMessages(uploadedMessages);
+      },
+      (error: FirestoreError) => {
+        if (process.env.NODE_ENV === "development") {
+          console.error(error);
+        }
+      }
+    );
+  };
+  useEffect(() => {
+    unsubscribe();
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+  return messages;
+};

--- a/src/interfaces/Message.ts
+++ b/src/interfaces/Message.ts
@@ -1,0 +1,8 @@
+export interface Message {
+  messageId: string;
+  senderUID: string;
+  senderAvatarURL: string;
+  message: string;
+  receiverUID: string;
+  timestamp: Date;
+}

--- a/src/routes/Comments.tsx
+++ b/src/routes/Comments.tsx
@@ -109,7 +109,7 @@ const Comments: React.VFC = () => {
                 event.preventDefault();
                 setComment(event.target.value);
               }}
-              className="w-full h-24 mb-4"
+              className="w-full h-24 mb-4 p-2 resize-none rounded-lg"
             >
               {comment}
             </textarea>

--- a/src/routes/DirectMessage.tsx
+++ b/src/routes/DirectMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { useAppSelector } from "../app/hooks";
 import { selectUser, LoginUser } from "../features/userSlice";
 import {
@@ -10,34 +10,58 @@ import {
 import { db } from "../firebase";
 import {
   doc,
-  DocumentData,
-  DocumentReference,
   setDoc,
   serverTimestamp,
+  DocumentReference,
+  DocumentData,
 } from "firebase/firestore";
+import { useMessages } from "../hooks/useMessages";
+import { Message } from "../interfaces/Message";
 import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewOutlined";
+import SendRounded from "@mui/icons-material/SendRounded";
 import { getRandomString } from "../functions/GetRandomString";
 
 const DirectMessage = () => {
   const params: Readonly<Params<string>> = useParams();
   const navigate: NavigateFunction = useNavigate();
   const loginUser: LoginUser = useAppSelector(selectUser);
-  const receiverUID: string = params.messageId!.split("-")[1];
-  console.log(receiverUID);
-  const senderUID: string = loginUser.uid;
-  const newMessage: React.RefObject<HTMLInputElement> =
-    useRef<HTMLInputElement>(null);
-  const roomId: string = `${senderUID}-${receiverUID}`;
-  const [unread, setUnread] = useState<boolean>(true);
-
+  const partnerUID: string = params.messageId!.split("-")[1];
+  const roomId: string = `${loginUser.uid}-${partnerUID}`;
+  const messages: Message[] = useMessages(roomId);
+  const [newMessage, setNewMessage] = useState<string>("");
+  const divElement = useRef<HTMLDivElement>(null);
   const sendMessage = () => {
-    const messageRef = doc(db, `rooms/${roomId}/messages/${getRandomString()}`);
-    setDoc(messageRef, {
-      senderUID: senderUID,
-      receiverUID: receiverUID,
+    const roomsRef: DocumentReference<DocumentData> = doc(
+      db,
+      `rooms/${roomId}`
+    );
+    setDoc(roomsRef, {
+      senderUID: loginUser.uid,
+      senderAvatarURL: loginUser.avatarURL,
+      receiverUID: partnerUID,
       timestamp: serverTimestamp(),
     });
+    const messageRef: DocumentReference<DocumentData> = doc(
+      db,
+      `rooms/${roomId}/messages/${getRandomString()}`
+    );
+    setDoc(messageRef, {
+      senderUID: loginUser.uid,
+      senderAvatarURL: loginUser.avatarURL,
+      receiverUID: partnerUID,
+      message: newMessage,
+      timestamp: serverTimestamp(),
+      unread: true,
+    });
+    setNewMessage("");
   };
+  const scrollToBottom: () => void = () => {
+    divElement.current!.scrollIntoView();
+  };
+
+  useLayoutEffect(() => {
+    scrollToBottom();
+  }, []);
 
   return (
     <div className="flex flex-col w-full min-h-screen h-full bg-slate-100 ">
@@ -53,12 +77,87 @@ const DirectMessage = () => {
         </button>
         <p className="w-20 mx-auto font-bold">メッセージ</p>
       </div>
-      <input type="text" className="mt-12" ref={newMessage} />
-      <button
-        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-          sendMessage();
-        }}
-      >送信</button>
+      <div className="mt-16 mb-32">
+        {messages.map((message: Message) => {
+          const currentTime: number = new Date().getTime();
+          if (message.timestamp) {
+            const messageTime: number = message.timestamp.getTime();
+            const moreThanOneDayAgo: boolean =
+              currentTime - messageTime > 86400000;
+            const moreThanOneMinutesAgo: boolean =
+              currentTime - messageTime > 60000;
+            const secondsAgo: number = Math.trunc(
+              (currentTime - messageTime) / 1000
+            );
+            const messageHour: string = `0${message.timestamp.getHours()}`;
+            const messageMinutes: string = `0${message.timestamp.getMinutes()}`;
+            return (
+              <div key={message.messageId}>
+                {message.timestamp && moreThanOneDayAgo && (
+                  <div className="flex justify-center">
+                    <p>
+                      {`${message.timestamp.getFullYear()}年${message.timestamp.getMonth()}月${message.timestamp.getDate()}日`}
+                    </p>
+                  </div>
+                )}
+                {message.senderUID === loginUser.uid ? (
+                  <div className="flex flex-row-reverse m-4">
+                    <div className="flex flex-col">
+                      <p
+                        className="max-w-xs h-full 
+                         p-4 bg-emerald-500 text-slate-100 rounded-t-3xl rounded-l-3xl"
+                      >
+                        {message.message}
+                      </p>
+                      <div className="flex flex-row-reverse">
+                        <p>
+                          {moreThanOneMinutesAgo
+                            ? `${messageHour.substring(messageHour.length - 2)}:
+                    ${messageMinutes.substring(messageMinutes.length - 2)}`
+                            : `${secondsAgo}秒前`}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div>
+                    <img
+                      src={message.senderAvatarURL}
+                      alt="送信者のアバター画像"
+                    />
+                    <p>{message.message}</p>
+                    <p>{message.timestamp}</p>
+                  </div>
+                )}
+              </div>
+            );
+          } else {
+            return null;
+          }
+        })}
+        <div ref={divElement} />
+      </div>
+      <div className="fixed flex w-screen items-end bottom-0 bg-slate-100">
+        <textarea
+          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+            event.preventDefault();
+            setNewMessage(event.target.value);
+          }}
+          value={newMessage}
+          className="w-10/12 h-24 m-4 p-2 resize-none rounded-lg outline-none"
+          placeholder="メッセージを入力してください。"
+        />
+        <button
+          className="block w-8 h-8 my-4  font-bold text-emerald-500 disabled:text-slate-400"
+          disabled={newMessage === ""}
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+            sendMessage();
+          }}
+        >
+          <SendRounded />
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -113,7 +113,7 @@ const Profile: React.VFC = memo(() => {
             alt="アバター画像"
           />
           <div className="flex justify-between w-40 p-2 mr-4">
-            {loginUser.uid !== user.uid && (
+            {loginUser && loginUser.uid !== user.uid && (
               <Link
                 to={`/messages/${loginUser.uid}-${user.uid}`}
                 state={{ receiverUID: user.uid }}
@@ -123,7 +123,7 @@ const Profile: React.VFC = memo(() => {
                 </button>
               </Link>
             )}
-            {loginUser.uid === user.uid ? (
+            {loginUser && loginUser.uid === user.uid ? (
               <Link
                 to={
                   loginUser.userType === "business"


### PR DESCRIPTION
## Issue
#266 

## 変更した内容
**src/hooks/useMessages.ts**
- [x] `DirectMessage`コンポーネントを表示した際に、Firestoreからメッセージの一覧を読み込むフックスを作成しました

**src/interfaces/Message.ts**
- [x] メッセージの型をインターフェースで定義しました

**src/routes/Comments.tsx**
- [x] `Comments`コンポーネントのうち、入力フォームのresize属性をオフにしました

**src/routes/DirectMessage.tsx**
- [x] roomsコレクションのドキュメントの中に送信者の情報と受信者の情報、タイムスタンプ等を記録するようにしました
- [x] 1日以上前に投稿されたメッセージがあった場合、画面上に投稿された日付が表示されるようにしました
- [x] 1分以内に投稿されたメッセージなら「○○秒前」、それ以上前に登録されたメッセージなら「○○:○○」と表示されるようにしました
- [x] 入力フォームのスタイリングをおこないました

src/routes/Profile.tsx
- [x] ログインしているユーザーでなければ、DM画面へリンクできないようにしました

## 動作の確認 
1. プロフィール画面のメールアイコンボタンをクリックして画面遷移
<img width="1440" alt="スクリーンショット 2022-10-02 8 17 08" src="https://user-images.githubusercontent.com/98272835/193431664-996af182-cbf0-411d-a243-f0a9e1f70369.png">

2. 画面上にこれまで送信されたメッセージの一覧が表示されることを確認しました
<img width="1440" alt="スクリーンショット 2022-10-02 8 17 24" src="https://user-images.githubusercontent.com/98272835/193431675-f6ac1fb1-bd86-4c5f-8cd2-df0cec4442d2.png">

- [x] 送信時刻が適正に表示されているか

3. 入力フォームに新規メッセージを入力できることを確認しました
<img width="1440" alt="スクリーンショット 2022-10-02 8 17 35" src="https://user-images.githubusercontent.com/98272835/193431688-fa3e889f-7b12-4a1b-a9f1-a9db22264557.png">

4. 送信したメッセージが適正に画面上に表示されることを確認しました
<img width="1440" alt="スクリーンショット 2022-10-02 8 17 45" src="https://user-images.githubusercontent.com/98272835/193431734-e82d1534-8372-44f3-8372-4d1a05b77700.png">

