### PR TITLE
✨ メッセージのやり取り履歴のあるユーザーの一覧表示機能を実装しました

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -33,7 +33,6 @@ export const useMessages: (roomId: string) => Message[] = (roomId) => {
             const value: DocumentData = messageSnap.data();
             const message: Message = {
               messageId: messageSnap.id,
-              senderAvatarURL: value.senderavatarURL,
               message: value.message,
               senderUID: value.senderUID,
               receiverUID: value.receiverUID,

--- a/src/hooks/useRooms.ts
+++ b/src/hooks/useRooms.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect } from "react";
+import { useAppSelector } from "../app/hooks";
+import { selectUser, LoginUser } from "../features/userSlice";
+import { db } from "../firebase";
+import {
+  collection,
+  onSnapshot,
+  QuerySnapshot,
+  DocumentData,
+  QueryDocumentSnapshot,
+  query,
+  Query,
+  FirestoreError,
+  where,
+  orderBy,
+} from "firebase/firestore";
+import { Room } from "../interfaces/Room";
+
+export const useRooms: () => Room[] = () => {
+  let isMounted: boolean = true;
+  const loginUser: LoginUser = useAppSelector(selectUser);
+  const [rooms, setRooms] = useState<Room[]>([]);
+
+  const unsubscribe = async (communicator: "senderUID" | "receiverUID") => {
+    const roomsQuery: Query<DocumentData> = query(
+      collection(db, "rooms"),
+      where(communicator, "==", loginUser.uid),
+      orderBy("timestamp", "asc")
+    );
+    onSnapshot(
+      roomsQuery,
+      (roomsSnap: QuerySnapshot<DocumentData>) => {
+        const mappedArray: Room[] = roomsSnap.docs.map(
+          (roomSnap: QueryDocumentSnapshot<DocumentData>) => {
+            return {
+              senderUID: roomSnap.data().senderUID,
+              senderAvatar: roomSnap.data().senderAvatar,
+              senderName: roomSnap.data().senderName,
+              receiverUID: roomSnap.data().receiverUID,
+              receiverAvatar: roomSnap.data().receiverAvatar,
+              receiverName: roomSnap.data().receiverName,
+              timestamp: roomSnap.data().timestamp,
+            };
+          }
+        );
+        if (isMounted) {
+          setRooms(mappedArray);
+        }
+      },
+      (error: FirestoreError) => {
+        if (process.env.NODE_ENV === "development") {
+          console.error(error);
+        }
+      }
+    );
+  };
+
+  useEffect(() => {
+    unsubscribe("senderUID");
+    unsubscribe("receiverUID");
+    return () => {
+      unsubscribe("senderUID");
+      unsubscribe("receiverUID");
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return rooms;
+};

--- a/src/hooks/useRooms.ts
+++ b/src/hooks/useRooms.ts
@@ -21,14 +21,14 @@ export const useRooms: () => Room[] = () => {
   const loginUser: LoginUser = useAppSelector(selectUser);
   const [rooms, setRooms] = useState<Room[]>([]);
 
-  const unsubscribe = async (communicator: "senderUID" | "receiverUID") => {
-    const roomsQuery: Query<DocumentData> = query(
+  const unsubscribe = async () => {
+    const messagesQuery: Query<DocumentData> = query(
       collection(db, "rooms"),
-      where(communicator, "==", loginUser.uid),
+      where("users", "array-contains", loginUser.uid),
       orderBy("timestamp", "asc")
     );
     onSnapshot(
-      roomsQuery,
+      messagesQuery,
       (roomsSnap: QuerySnapshot<DocumentData>) => {
         const mappedArray: Room[] = roomsSnap.docs.map(
           (roomSnap: QueryDocumentSnapshot<DocumentData>) => {
@@ -36,14 +36,17 @@ export const useRooms: () => Room[] = () => {
               senderUID: roomSnap.data().senderUID,
               senderAvatar: roomSnap.data().senderAvatar,
               senderName: roomSnap.data().senderName,
+              senderDisplayName: roomSnap.data().displayName,
               receiverUID: roomSnap.data().receiverUID,
               receiverAvatar: roomSnap.data().receiverAvatar,
               receiverName: roomSnap.data().receiverName,
+              receiverDisplayName:roomSnap.data().displayName,
               timestamp: roomSnap.data().timestamp,
             };
           }
         );
         if (isMounted) {
+          console.log(mappedArray);
           setRooms(mappedArray);
         }
       },
@@ -56,11 +59,11 @@ export const useRooms: () => Room[] = () => {
   };
 
   useEffect(() => {
-    unsubscribe("senderUID");
-    unsubscribe("receiverUID");
+    unsubscribe();
     return () => {
-      unsubscribe("senderUID");
-      unsubscribe("receiverUID");
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      isMounted = false;
+      unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import Followers from "./routes/Followers";
 import Followings from "./routes/Followings";
 import Home from "./routes/Home";
 import Search from "./routes/Search";
+import Notifications from "./routes/Notifications";
+import Rooms from "./routes/Rooms";
 import Post from "./routes/PostDetail";
 import LikeUsers from "./routes/LikeUsers";
 import Comments from "./routes/Comments";
@@ -29,7 +31,7 @@ ReactDOM.render(
           <Route path="/*" element={<App />}>
             <Route path="home" element={<Home />} />
             <Route path="search" element={<Search />} />
-            <Route path="notifications" element={<p>Notifications</p>} />
+            <Route path="notifications" element={<Notifications />} />
             <Route path="email" element={<p>Email</p>} />
           </Route>
           <Route path="/login" element={<Login />} />
@@ -43,7 +45,8 @@ ReactDOM.render(
           <Route path="/:username/:docId/comments" element={<Comments />} />
           <Route path="/:username/followers" element={<Followers />} />
           <Route path="/:username/followings" element={<Followings />} />
-          <Route path="/messages/:messageId" element={<DirectMessage/>} />
+          <Route path="/messages" element={<Rooms />} />
+          <Route path="/messages/:messageId" element={<DirectMessage />} />
         </Routes>
       </BrowserRouter>
     </Provider>

--- a/src/interfaces/Message.ts
+++ b/src/interfaces/Message.ts
@@ -1,7 +1,6 @@
 export interface Message {
   messageId: string;
   senderUID: string;
-  senderAvatarURL: string;
   message: string;
   receiverUID: string;
   timestamp: Date;

--- a/src/interfaces/Room.ts
+++ b/src/interfaces/Room.ts
@@ -2,8 +2,10 @@ export interface Room {
   senderUID: string;
   senderAvatar: string;
   senderName: string;
+  senderDisplayName: string;
   receiverUID: string;
   receiverAvatar: string;
   receiverName: string;
+  receiverDisplayName: string;
   timestamp: Date;
 }

--- a/src/interfaces/Room.ts
+++ b/src/interfaces/Room.ts
@@ -1,0 +1,9 @@
+export interface Room {
+  senderUID: string;
+  senderAvatar: string;
+  senderName: string;
+  receiverUID: string;
+  receiverAvatar: string;
+  receiverName: string;
+  timestamp: Date;
+}

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -1,0 +1,14 @@
+import React, { useState } from "react";
+import { Link, Outlet } from "react-router-dom";
+import Rooms from "../routes/Rooms";
+
+const Notifications = () => {
+  return (
+    <div>
+      <button>通知</button>
+      <Link to="/messages">メッセージ</Link>
+    </div>
+  );
+};
+
+export default Notifications;

--- a/src/routes/Rooms.tsx
+++ b/src/routes/Rooms.tsx
@@ -11,6 +11,7 @@ interface Partner {
 }
 
 const Rooms = () => {
+  console.log("rooms");
   const loginUser: LoginUser = useAppSelector(selectUser);
   const rooms: Room[] = useRooms();
   return (

--- a/src/routes/Rooms.tsx
+++ b/src/routes/Rooms.tsx
@@ -1,0 +1,47 @@
+import { useAppSelector } from "../app/hooks";
+import { selectUser, LoginUser } from "../features/userSlice";
+import { Link } from "react-router-dom";
+import { useRooms } from "../hooks/useRooms";
+import { Room } from "../interfaces/Room";
+
+interface Partner {
+  uid: string;
+  username: string;
+  avatarURL: string;
+}
+
+const Rooms = () => {
+  const loginUser: LoginUser = useAppSelector(selectUser);
+  const rooms: Room[] = useRooms();
+  return (
+    <div>
+      <ul>
+        {rooms.map((room: Room) => {
+          const messageId: string = `${room.senderUID}-${room.receiverUID}`;
+          const isSender: boolean = room.senderUID === loginUser.uid;
+          const partner: Partner = {
+            uid: isSender ? room.receiverUID : room.senderUID,
+            username: isSender ? room.receiverName : room.senderName,
+            avatarURL: isSender ? room.receiverAvatar : room.senderAvatar,
+          };
+          return (
+            <div key={messageId}>
+              <Link to={`/messages/${messageId}`} >
+                <li>
+                  <div>
+                    <img src={partner.avatarURL} alt="ユーザーのアバター画像" />
+                  </div>
+                  <div>
+                    <p>{partner.username}</p>
+                  </div>
+                </li>
+              </Link>
+            </div>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default Rooms;


### PR DESCRIPTION
## Issue
#268 

## 変更した内容
**src/hooks/useMessages.ts**
- [x] firestoreの親ドキュメントからアバター画像を読み込むため、不要となる`senderAvatarURL`の情報を削除しました

**src/hooks/useRooms.ts**
- [x] roomsコレクションから、loginUserのUIDをもつドキュメントを取得し、登録されている情報をリターンするフックスを作成しました

**src/index.tsx**
- [x] ルート情報に`<notifications />`コンポーネントと`<Rooms />`、`<DirectMessage />`の情報を追加しました

**src/routes/DirectMessage.tsx**
- [x] ユーザーUIDと異なるUIDを持つ通信相手のUIDをpartnerUIDという変数で管理するようにしました
- [x] `getPartner()`という関数で、partnerUIDをもつユーザーの情報を取得できるようにしました
- [x] 投稿日時からの経過時間によって、時間表記を変更するようにしました（１分以内なら○○秒前と表示されます）

** 動作の確認 **

1. タブバーから「通知」画面へと遷移する
<img width="1440" alt="スクリーンショット 2022-10-04 22 13 35" src="https://user-images.githubusercontent.com/98272835/193831972-46c30da2-1092-4dc1-be1d-bd6dc3a938d4.png">

2. 「メッセージ」ボタンをクリックする
- [x] チャット通信中のユーザー一覧が表示されることを確認
<img width="1440" alt="スクリーンショット 2022-10-04 22 13 43" src="https://user-images.githubusercontent.com/98272835/193832180-ea24cc7b-7e43-4607-bb86-b9602c144bb1.png">


3. ユーザーのアバター画像をクリックする
- [x] チャット画面に遷移することを確認
<img width="1440" alt="スクリーンショット 2022-10-04 22 13 53" src="https://user-images.githubusercontent.com/98272835/193832519-5a59a284-a999-4333-b1bd-aa729e715c8d.png">
