### PR TITLE
🐛 他ユーザーのプロフィール画面から自身のプロフィール画面へ遷移できるようにしました

### DIFF
--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -44,6 +44,7 @@ export const useProfile: (username: string) => {
   isFollowing: boolean;
   loginUser: LoginUser;
 } = (username: string) => {
+  console.log(username);
   const [user, setUser] = useState<User>({
     avatarURL: "",
     backgroundURL: "",
@@ -149,7 +150,7 @@ export const useProfile: (username: string) => {
       unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [username]);
   return {
     user: user,
     option: option,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -44,7 +44,6 @@ export const useProfile: (username: string) => {
   isFollowing: boolean;
   loginUser: LoginUser;
 } = (username: string) => {
-  console.log(username);
   const [user, setUser] = useState<User>({
     avatarURL: "",
     backgroundURL: "",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,7 @@ ReactDOM.render(
           <Route path="/setting/business" element={<SettingBusiness />} />
           <Route path="/setting/normal" element={<SettingNormal />} />
           <Route path="/setting/advertise" element={<SettingAdvertise />} />
-          <Route path="/:username" element={<Profile />} />
+          <Route path="/:username/*" element={<Profile />} />
           <Route path="/:username/:docId" element={<Post />} />
           <Route path="/:username/:docId/likeUsers" element={<LikeUsers />} />
           <Route path="/:username/:docId/comments" element={<Comments />} />

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -42,8 +42,10 @@ interface FollowUser {
 
 const Profile: React.VFC = memo(() => {
   const params: Readonly<Params<string>> = useParams();
-  const username: string = params.username!;
   const navigate: NavigateFunction = useNavigate();
+  const username: string = params.username!;
+  const [scroll, setScroll] = useState<number>(0);
+  const [tab, setTab] = useState<"album" | "wanted">("album");
   const {
     user,
     option,
@@ -58,8 +60,6 @@ const Profile: React.VFC = memo(() => {
   const closingHour: string = `0${advertise.closingHour}`;
   const closingMinutes: string = `0${advertise.closingMinutes}`;
   const posts: Post[] = usePosts(username);
-  const [scroll, setScroll] = useState<number>(0);
-  const [tab, setTab] = useState<"album" | "wanted">("album");
   let isMounted: boolean = true;
 
   useEffect(() => {


### PR DESCRIPTION
## Issue
#324 

## 変更した内容
**src/hooks/useProfile.ts**
- [x] useEffectのトリガーとなる変数として、プロパティの`username`を設定しました

**src/index.tsx**
- [x] エラーの警告文の内容を確認し、`<Route path="/:username" element={<Profile />} />`の記述を` <Route path="/:username/*" element={<Profile />} />`に改めました

## 動作の確認
1. 検索画面に遷移し、任意のキーワードで検索し、検索結果を表示する
<img width="1440" alt="スクリーンショット 2022-11-03 20 29 36" src="https://user-images.githubusercontent.com/98272835/199710355-ceb020ff-4540-4616-a4b2-a9df02b5beda.png">

2. 検索結果から自分以外のユーザーのプロフィール画面に遷移する
<img width="1440" alt="スクリーンショット 2022-11-03 20 29 44" src="https://user-images.githubusercontent.com/98272835/199710476-627a5a2e-4242-4324-8b74-61f32f7c4c41.png">

3. 自分以外のユーザーのプロフィール画面を表示している状態で、タブバーの「自分」ボタンをクリックする
4. 自分自身のプロフィール画面が表示されることを確認
<img width="1440" alt="スクリーンショット 2022-11-03 20 29 50" src="https://user-images.githubusercontent.com/98272835/199710505-02bfa795-e822-4728-a77d-8fd315e50de9.png">
