### PR TITLE
🐛 プロフィール編集画面のエラーを解決しました。また、レスポンシブ対応できるようスタイリングしました

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -81,8 +81,12 @@ const TabBar = (props: { invisibleAtSmall: boolean }) => {
             to={`/${loginUser.username}`}
           >
             <img
-              className="block w-8 h-8 mx-auto rounded-full"
-              src={loginUser.avatarURL}
+              className="block w-8 h-8 mx-auto rounded-full object-cover"
+              src={
+                loginUser.avatarURL !== ""
+                  ? loginUser.avatarURL
+                  : `${process.env.PUBLIC_URL}/noAvatar.png`
+              }
               alt={`${loginUser.username}のアバター`}
             />
             <p className="text-xs">自分</p>

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -17,6 +17,7 @@ import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewRounded";
 import MailOutlined from "@mui/icons-material/MailOutlined";
 import PhotoLibraryOutlined from "@mui/icons-material/PhotoLibraryOutlined";
 import PersonAddOutlined from "@mui/icons-material/PersonAddOutlined";
+import PersonOutline from "@mui/icons-material/PersonOutline";
 import { useAdvertise } from "../hooks/useAdvertise";
 
 interface Post {
@@ -116,16 +117,19 @@ const Profile: React.VFC = memo(() => {
             />
           </div>
           <div className="relative">
-            <img
-              className="w-20 h-20 ml-4 -mt-8 border-4 border-white object-cover rounded-full"
-              id="avatar"
-              src={
-                user.avatarURL
-                  ? user.avatarURL
-                  : `${process.env.PUBLIC_URL}/noAvatar.png`
-              }
-              alt="アバター画像"
-            />
+            {user.avatarURL ? (
+              <img
+                className="-mt-8 ml-4 w-20 h-20 border-4 border-white rounded-full object-cover brightness-75"
+                src={user.avatarURL}
+                alt="アバター画像"
+              />
+            ) : (
+              <div className="flex w-20 h-20 justify-center items-center -mt-8 ml-4 border-4 border-white bg-slate-500 text-white rounded-full">
+                {" "}
+                <PersonOutline fontSize="large" />
+              </div>
+            )}
+
             {loginUser && loginUser.uid !== user.uid && (
               <Link
                 to={`/messages/${loginUser.uid}-${user.uid}`}
@@ -403,7 +407,7 @@ const Profile: React.VFC = memo(() => {
                           advertise.wanted
                             ? "absolute right-2 bottom-2"
                             : "mt-4"
-                        } rounded-full border border-emerald-500 text-emerald-500 bg-white hover:border-none hover:text-slate-100 hover:bg-emerald-500 font-bold`}
+                        } rounded-full border border-emerald-500 text-emerald-500 bg-white hover:border-none hover:text-white hover:bg-emerald-500 active:text-white active:bg-emerald-500 font-bold`}
                       >
                         募集広告の編集
                       </button>

--- a/src/routes/SettingAdvertise.tsx
+++ b/src/routes/SettingAdvertise.tsx
@@ -51,16 +51,10 @@ const SettingAdvertise = () => {
   const getAdvertise = () => {
     getDoc(advertiseRef).then(
       (advertiseSnap: DocumentSnapshot<DocumentData>) => {
-        if (advertiseSnap.exists()) {
+        if (advertiseSnap.exists() && isMounted) {
           setAdvertiseImage(advertiseSnap.data()!.imageURL);
-          const closingHourSnap = advertiseSnap.data()?.closingHour;
-          closingHour.current!.value = `0${closingHourSnap}`.substring(
-            `0${closingHourSnap}`.length - 2
-          );
-          const closingMinutesSnap = advertiseSnap.data()?.closingMinutes;
-          closingMinutes.current!.value = `0${closingMinutesSnap}`.substring(
-            `0${closingMinutesSnap}`.length - 2
-          );
+          closingHour.current!.value = advertiseSnap.data()!.closingHour;
+          closingMinutes.current!.value = advertiseSnap.data()!.closingMinutes;
           setJobDescription(advertiseSnap.data()!.jobDescription);
           location.current!.value = advertiseSnap.data()!.location;
           maximumWage.current!.value = advertiseSnap.data()!.maximumWage;
@@ -125,7 +119,7 @@ const SettingAdvertise = () => {
         username: loginUser.username,
         wanted: wanted,
       },
-      {merge:true}
+      { merge: true }
     ).then(() => {
       setTimeout(() => {
         navigate(`/${loginUser.username}`);
@@ -144,217 +138,208 @@ const SettingAdvertise = () => {
   }, [isFetched]);
 
   return (
-    <div className="bg-slage-100">
-      <div className="flex fixed justify-center items-center top-0 w-screen h-12 z-10 bg-slate-100">
-        <button
-          className="absolute left-2"
-          onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-            event.preventDefault();
-            navigate(-1);
-          }}
-        >
-          <ArrowBackRounded />
-        </button>
-        <p className="w-40 mx-auto font-bold">募集広告の編集</p>
-      </div>
-      <div className="bg-slate-100">
-        <div className="relative mt-12">
-          <img
-            className="w-screen h-44 object-cover brightness-50"
-            src={
-              advertiseImage
-                ? advertiseImage
-                : `${process.env.PUBLIC_URL}/noPhoto.png`
-            }
-            alt="イメージ画像"
-          />
-          <input
-            id="advertiseImageInput"
-            type="file"
-            accept="image/*"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              event.preventDefault();
-              onChangeImageHandler(event);
-            }}
-            hidden
-          />
-          <label
-            className="flex absolute bottom-2 left-4 text-slate-100"
-            htmlFor="advertiseImageInput"
-          >
-            <PhotoLibraryOutlined fontSize="large" />
-            <p className="ml-4 leading-8">イメージ画像を選択</p>
-          </label>
-          <div className="absolute flex items-center inset-y-1/2 left-4 ">
-            <img
-              className="w-12 h-12 mr-2 border-2 border-slate-100 object-cover rounded-full"
-              id="avatar"
-              src={
-                loginUser.avatarURL
-                  ? loginUser.avatarURL
-                  : `${process.env.PUBLIC_URL}/noAvatar.png`
-              }
-              alt="アバター画像"
-            />
-            <p className="text-xl text-slate-100 font-semibold">
-              {loginUser.displayName}
-            </p>
-          </div>
+    <div className="md:flex md:justify-center w-screen h-full min-h-screen bg-slate-400">
+      <div className="w-screen md:w-1/2 lg:w-1/3 h-full bg-white">
+        <div className="flex fixed w-screen md:w-1/2 lg:w-1/3 h-12 justify-center items-center top-0  z-10 bg-white">
           <button
-            className="absolute right-4 bottom-2 p-2 rounded-full border border-slate-100 text-slate-100"
-            onClick={(
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-            ) => {
-              event.preventDefault();
-              setAdvertiseImage("");
+            className="absolute left-2"
+            onClick={() => {
+              navigate(-1);
             }}
-            disabled={!advertiseImage}
           >
-            <CloseRounded />
+            <ArrowBackRounded />
           </button>
+          <p className="w-28 mx-auto font-bold">募集広告の編集</p>
         </div>
-        <div className="p-4">
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">メッセージ</p>
-            <textarea
-              className="w-full h-32 p-2 border-none bg-slate-200 rounded-md resize-none"
-              placeholder="応募者へのメッセージを入力してください"
-              value={message}
-              onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                event.preventDefault();
-                setMessage(event.target.value);
+        <div className="mt-12">
+          <div className="relative">
+            <img
+              className="w-full h-44 object-cover brightness-50"
+              src={
+                advertiseImage
+                  ? advertiseImage
+                  : `${process.env.PUBLIC_URL}/noPhoto.png`
+              }
+              alt="イメージ画像"
+            />
+            <input
+              id="advertiseImageInput"
+              type="file"
+              accept="image/*"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                onChangeImageHandler(event);
               }}
+              hidden
             />
-          </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">勤務内容</p>
-            <textarea
-              className="w-full h-32 p-2 border-none bg-slate-200 rounded-md resize-none"
-              value={jobDescription}
-              onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                event.preventDefault();
-                setJobDescription(event.target.value);
+            <label
+              className="flex absolute bottom-2 left-4 text-white align-middle"
+              htmlFor="advertiseImageInput"
+            >
+              <PhotoLibraryOutlined />
+              <p className="ml-2">イメージ画像を選択</p>
+            </label>
+            <div className="absolute flex items-center inset-y-1/2 left-4 ">
+              <img
+                className="w-12 h-12 mr-2 border-2 border-white object-cover rounded-full"
+                id="avatar"
+                src={
+                  loginUser.avatarURL
+                    ? loginUser.avatarURL
+                    : `${process.env.PUBLIC_URL}/noAvatar.png`
+                }
+                alt="アバター画像"
+              />
+              <p className="text-xl text-white font-semibold">
+                {loginUser.displayName}
+              </p>
+            </div>
+            <button
+              className="absolute right-4 bottom-2 p-2 rounded-full border border-white text-white active:border-none active:bg-white active:text-slate-500 cursor-pointer duration-[100ms]"
+              onClick={() => {
+                setAdvertiseImage("");
               }}
-            />
+              disabled={!advertiseImage}
+            >
+              <CloseRounded />
+            </button>
           </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">勤務地</p>
-            <input
-              className="h-8 w-full p-2 bg-slate-200 rounded-md"
-              type="text"
-              ref={location}
-            />
-          </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">給与</p>
-            <input
-              type="number"
-              ref={minimumWage}
-              className="w-20 h-8 p-2 bg-slate-200 rounded-md"
-            />
-            <label className="ml-2">円</label>
-            <label className="mx-2">〜</label>
-            <input
-              type="number"
-              ref={maximumWage}
-              className="w-20 h-8 p-2 bg-slate-200 rounded-md"
-            />
-            <label className="ml-2">円</label>
-          </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">勤務時間</p>
-            <div className="flex items-center h-8 w-full p-2 bg-slate-200 rounded-md">
-              <select ref={openingHour} className="bg-slate-100">
-                {[
-                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                  18, 19, 20, 21, 22, 23, 24,
-                ].map((hour: number) => {
-                  return (
-                    <option key={hour}>
-                      {`0${hour}`.substring(`0${hour}`.length - 2)}
-                    </option>
-                  );
-                })}
-              </select>
-              <label className="w-2">:</label>
-              <select ref={openingMinutes} className="bg-slate-100">
-                {minutesArray.map((minutes) => {
-                  return (
-                    <option key={minutes}>
-                      {`0${minutes}`.substring(`0${minutes}`.length - 2)}
-                    </option>
-                  );
-                })}
-              </select>
-              <label className="mx-2">~</label>
-              <select ref={closingHour} className="bg-slate-100">
-                {[
-                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                  18, 19, 20, 21, 22, 23, 24,
-                ].map((hour: number) => {
-                  return (
-                    <option key={hour}>
-                      {`0${hour}`.substring(`0${hour}`.length - 2)}
-                    </option>
-                  );
-                })}
-              </select>
-              <label className="w-2">:</label>
-              <select ref={closingMinutes} className="bg-slate-100">
-                {minutesArray.map((minutes) => {
-                  return (
-                    <option key={minutes}>
-                      {`0${minutes}`.substring(`0${minutes}`.length - 2)}
-                    </option>
-                  );
-                })}
-              </select>
+          <div className="p-4">
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">メッセージ</p>
+              <textarea
+                className="w-full h-32 p-2 border-none bg-slate-200 rounded-md resize-none"
+                placeholder="応募者へのメッセージを入力してください"
+                value={message}
+                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  setMessage(event.target.value);
+                }}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">勤務内容</p>
+              <textarea
+                className="w-full h-32 p-2 border-none bg-slate-200 rounded-md resize-none"
+                value={jobDescription}
+                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  setJobDescription(event.target.value);
+                }}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">勤務地</p>
+              <input
+                className="h-8 w-full p-2 bg-slate-200 rounded-md"
+                type="text"
+                ref={location}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">給与</p>
+              <input
+                type="number"
+                ref={minimumWage}
+                className="w-20 h-8 p-2 bg-slate-200 rounded-md"
+              />
+              <label className="ml-2">円</label>
+              <label className="mx-2">〜</label>
+              <input
+                type="number"
+                ref={maximumWage}
+                className="w-20 h-8 p-2 bg-slate-200 rounded-md"
+              />
+              <label className="ml-2">円</label>
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">勤務時間</p>
+              <div className="flex items-center h-8 w-full p-2 bg-slate-200 rounded-md">
+                <select ref={openingHour} className="bg-white">
+                  {[
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                    17, 18, 19, 20, 21, 22, 23, 24,
+                  ].map((hour: number) => {
+                    return (
+                      <option key={hour}>
+                        {`0${hour}`.substring(`0${hour}`.length - 2)}
+                      </option>
+                    );
+                  })}
+                </select>
+                <label className="w-2">:</label>
+                <select ref={openingMinutes} className="bg-white">
+                  {minutesArray.map((minutes) => {
+                    return (
+                      <option key={minutes}>
+                        {`0${minutes}`.substring(`0${minutes}`.length - 2)}
+                      </option>
+                    );
+                  })}
+                </select>
+                <label className="mx-2">~</label>
+                <select ref={closingHour} className="bg-white">
+                  {[
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                    17, 18, 19, 20, 21, 22, 23, 24,
+                  ].map((hour: number) => {
+                    return (
+                      <option key={hour}>
+                        {`0${hour}`.substring(`0${hour}`.length - 2)}
+                      </option>
+                    );
+                  })}
+                </select>
+                <label className="w-2">:</label>
+                <select ref={closingMinutes} className="bg-white">
+                  {minutesArray.map((minutes) => {
+                    return (
+                      <option key={minutes}>
+                        {`0${minutes}`.substring(`0${minutes}`.length - 2)}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
             </div>
           </div>
-        </div>
-        <div className="flex items-center mb-8">
-          <div
-            className={`relative w-16 h-8 mx-4 rounded-full ${
-              wanted
-                ? "bg-emerald-500 duration-[300ms]"
-                : "bg-slate-200 duration-[300ms]"
-            } `}
-          >
-            <button
-              id="wanted"
-              className={`absolute w-8 h-8 ${
-                wanted ? "left-8 duration-[300ms]" : "left-0 duration-[300ms]"
-              } rounded-full drop-shadow-lg bg-slate-100`}
-              onClick={(
-                event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-              ) => {
-                event.preventDefault();
-                setWanted((prev) => {
-                  return !prev;
-                });
-              }}
-            />
+          <div className="flex items-center mb-8">
+            <div
+              className={`relative w-16 h-8 mx-4 rounded-full ${
+                wanted
+                  ? "bg-emerald-500 duration-[300ms]"
+                  : "bg-slate-200 duration-[300ms]"
+              } `}
+            >
+              <button
+                id="wanted"
+                className={`absolute w-8 h-8 ${
+                  wanted ? "left-8 duration-[300ms]" : "left-0 duration-[300ms]"
+                } rounded-full drop-shadow-lg bg-white`}
+                onClick={() => {
+                  setWanted((prev) => {
+                    return !prev;
+                  });
+                }}
+              />
+            </div>
+            <label
+              className={wanted ? "text-slate-800" : "text-slate-400"}
+              htmlFor="wanted"
+            >
+              {wanted ? "公開する" : "公開しない"}
+            </label>
           </div>
-          <label
-            className={wanted ? "text-slate-800" : "text-slate-400"}
-            htmlFor="wanted"
-          >
-            {wanted ? "公開する" : "公開しない"}
-          </label>
-        </div>
-        <div className="pb-8">
-          <button
-            className="block w-24 h-8 m-auto border rounded-full font-bold border-emerald-500 text-emerald-500 hover:border-none hover:bg-emerald-500 hover:text-slate-100 disabled:border-slate-400 disabled:text-slate-400 disabled:bg-slate-300"
-            onClick={(
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-            ) => {
-              event.preventDefault();
-              handleSubmit();
-            }}
-            disabled={message === "" || jobDescription === ""}
-          >
-            登録する
-          </button>
+          <div className="pb-8">
+            <button
+              className="block w-24 h-8 m-auto border rounded-full font-bold border-emerald-500 text-emerald-500 hover:border-none hover:bg-emerald-500 hover:text-white 
+              active:bg-emerald-500 active:text-white
+              disabled:border-slate-400 disabled:text-slate-400 disabled:bg-slate-300 duration-[200ms]"
+              onClick={() => {
+                handleSubmit();
+              }}
+              disabled={message === "" || jobDescription === ""}
+            >
+              登録する
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/routes/SettingBusiness.tsx
+++ b/src/routes/SettingBusiness.tsx
@@ -49,7 +49,6 @@ const SettingBusiness = () => {
   const introduction = useRef<HTMLTextAreaElement>(null);
   const owner = useRef<HTMLInputElement>(null);
   const typeOfWork = useRef<HTMLInputElement>(null);
-
   const navigate: NavigateFunction = useNavigate();
   const loginUser: LoginUser = useAppSelector(selectUser);
   const dispatch = useAppDispatch();
@@ -84,6 +83,9 @@ const SettingBusiness = () => {
   );
 
   const getUser = async () => {
+    if (isMounted === false) {
+      return;
+    }
     setAvatarImage(loginUser.avatarURL);
     setBackgroundImage(loginUser.backgroundURL);
     setDisplayName(loginUser.displayName);
@@ -105,7 +107,6 @@ const SettingBusiness = () => {
     event: React.ChangeEvent<HTMLInputElement>,
     imageFor: "avatar" | "background"
   ) => void = (event, imageFor) => {
-    event.preventDefault();
     const file: File = event.target.files![0];
     if (["image/png", "image/jpeg"].includes(file.type) === true) {
       const reader: FileReader = new FileReader();
@@ -130,6 +131,9 @@ const SettingBusiness = () => {
   };
 
   const handleSubmit = async () => {
+    if (isMounted === false) {
+      return;
+    }
     // NOTE >> getDownloadURL()を使ってStorageから画像のURLを取得することも
     //         検討しましたが、画像を削除する処理を行なった後、ふたたび
     //         プロフィール編集画面を開いた際に、useEffect内の処理（ステートに
@@ -171,18 +175,15 @@ const SettingBusiness = () => {
       backgroundURL: backgroundURL,
       displayName: displayName,
       introduction: introduction.current!.value,
-      uid: `${loginUser.uid}`,
       username: `@${username.input}`,
     });
-    updateDoc(usernameRef,{
-      uid: `${loginUser.uid}`,
+    updateDoc(usernameRef, {
       username: `@${username.input}`,
-    })
+    });
     updateDoc(optionRef, {
       address: address.current!.value,
       owner: owner.current!.value,
       typeOfWork: typeOfWork.current!.value,
-      uid: `${loginUser.uid}`,
       username: `@${username.input}`,
     });
     updateProfile(auth.currentUser!, {
@@ -201,11 +202,11 @@ const SettingBusiness = () => {
         });
       })
       .then(() => {
-        getDoc(optionRef).then((userSnap: DocumentSnapshot<DocumentData>) => {
-          setTimeout(() => {
-            navigate(`/${userSnap.data()!.username}`);
-          }, 300);
-        });
+        // getDoc(optionRef).then((userSnap: DocumentSnapshot<DocumentData>) => {
+        setTimeout(() => {
+          navigate(`/@${username.input}`);
+        }, 300);
+        // });
       });
   };
   useEffect(() => {
@@ -220,186 +221,181 @@ const SettingBusiness = () => {
   }, [isFetched]);
 
   return (
-    <div className="pb-12 bg-slage-100">
-      <div className="flex fixed justify-center items-center top-0 w-screen h-12 z-10 bg-slate-100">
-        <button
-          className="absolute left-2"
-          onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-            event.preventDefault();
-            navigate(-1);
-          }}
-        >
-          <ArrowBackRounded />
-        </button>
-        <p className="w-40 mx-auto font-bold">プロフィールの編集</p>
-      </div>
-      <div className="mt-12">
-        <div className="flex relative jutify-center items-center w-screen h-44 hover:cursor-pointer">
-          <img
-            className="w-screen h-44 object-cover brightness-75"
-            src={
-              backgroundImage
-                ? backgroundImage
-                : `${process.env.PUBLIC_URL}/noPhoto.png`
-            }
-            alt="背景画像"
-          />
-          <input
-            id="backgroundInput"
-            type="file"
-            accept="image/*"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              event.preventDefault();
-              onChangeImageHandler(event, "background");
-            }}
-            hidden
-          />
-          <label
-            className="flex absolute left-4 text-slate-100"
-            htmlFor="backgroundInput"
-          >
-            <PhotoLibraryOutlined fontSize="large" />
-            <p className="ml-4 leading-8">背景を選択</p>
-          </label>
+    <div className="md:flex md:justify-center w-screen h-full min-h-screen bg-slate-400">
+      <div className="w-screen md:w-1/2 lg:w-1/3 h-full bg-white">
+        <div className="flex fixed w-screen md:w-1/2 lg:w-1/3 h-12 justify-center items-center top-0 z-10 bg-white">
           <button
-            className="absolute right-4 bottom-4 p-2 rounded-full border border-slate-100 text-slate-100"
-            onClick={(
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-            ) => {
-              event.preventDefault();
-              setBackgroundImage("");
+            className="absolute left-2"
+            onClick={() => {
+              navigate(-1);
             }}
-            disabled={!backgroundImage}
           >
-            <CloseRounded />
+            <ArrowBackRounded />
           </button>
+          <p className="w-40 mx-auto font-bold">プロフィールの編集</p>
         </div>
-        <div className="relative">
-          <input
-            id="avatarInput"
-            type="file"
-            accept="image/*"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              event.preventDefault();
-              onChangeImageHandler(event, "avatar");
-            }}
-            hidden
-          />
-          {avatarImage ? (
+        <div className="mt-12">
+          <div className="flex relative jutify-center items-center h-44 cursor-pointer">
             <img
-              className="-mt-8 ml-4 w-20 h-20 border-4 border-slate-100 rounded-full object-cover brightness-75"
-              src={avatarImage}
-              alt="アバター画像"
+              className="w-full h-44 object-cover brightness-75"
+              src={
+                backgroundImage
+                  ? backgroundImage
+                  : `${process.env.PUBLIC_URL}/noPhoto.png`
+              }
+              alt="背景画像"
             />
-          ) : (
-            <div className="-mt-8 ml-4 w-20 h-20 border-4 border-slate-100 bg-slate-500 rounded-full" />
-          )}
-          <label
-            htmlFor="avatarInput"
-            className="absolute flex justify-center items-center w-20 h-20 border-4 top-0 left-4 border-slate-100 rounded-full text-slate-100 hover:cursor-pointer"
-          >
-            <div className="box rounded-full">
-              <PersonOutline fontSize="large" />
-            </div>
-          </label>
-          <button
-            className="absolute bottom-0 left-24 p-1 border border-slate-500 rounded-full text-slate-500"
-            onClick={(
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-            ) => {
-              event.preventDefault();
-              setAvatarImage("");
-            }}
-            disabled={!avatarImage}
-          >
-            <CloseRounded />
-          </button>
-        </div>
-        <div className="p-4">
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">ユーザー名</p>
             <input
-              className="h-8 w-full p-4  bg-slate-200 rounded-md"
-              type="text"
-              value={username.input}
-              onChange={async (event: React.ChangeEvent<HTMLInputElement>) => {
-                event.preventDefault();
-                setUsername(await checkUsername(event.target.value));
+              id="backgroundInput"
+              type="file"
+              accept="image/*"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                onChangeImageHandler(event, "background");
               }}
+              hidden
             />
-            <p className="text-sm text-red-500">
-              {username.uniqueCheck === false &&
-                "既に使用されているユーザー名です。"}
-            </p>
-            <p className="text-sm text-red-500">
-              {username.patternCheck === false &&
-                "入力できない文字が含まれいます。"}
-            </p>
-          </div>
-          <div className="mb-4">
-            <label htmlFor="displayName" className="text-sm text-slate-500">
-              企業名
+            <label
+              className="flex absolute left-4 text-white"
+              htmlFor="backgroundInput"
+            >
+              <PhotoLibraryOutlined fontSize="large" />
+              <p className="ml-4 leading-8">背景を選択</p>
             </label>
-            <input
-              id="displayName"
-              className="h-8 w-full p-4 bg-slate-200 rounded-md"
-              type="text"
-              value={displayName}
-              onChange={async (event: React.ChangeEvent<HTMLInputElement>) => {
-                setDisplayName(event.target.value);
+            <button
+              className="absolute right-4 bottom-4 p-2 rounded-full border border-white text-white active:border-none active:bg-white active:text-slate-500 cursor-pointer duration-[100ms]"
+              onClick={() => {
+                setBackgroundImage("");
               }}
-            />
+              disabled={!backgroundImage}
+            >
+              <CloseRounded />
+            </button>
           </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">紹介文</p>
-            <textarea
-              className="w-full h-32 p-2 border-none bg-slate-200 rounded-md resize-none"
-              ref={introduction}
-              defaultValue={loginUser.introduction}
-            />
-          </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">事業主</p>
+          <div className="relative">
             <input
-              className="h-8 w-full p-4  bg-slate-200 rounded-md"
-              type="text"
-              ref={owner}
+              id="avatarInput"
+              type="file"
+              accept="image/*"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                onChangeImageHandler(event, "avatar");
+              }}
+              hidden
             />
+            {avatarImage ? (
+              <img
+                className="-mt-8 ml-4 w-20 h-20 border-4 border-white rounded-full object-cover brightness-75"
+                src={avatarImage}
+                alt="アバター画像"
+              />
+            ) : (
+              <div className="-mt-8 ml-4 w-20 h-20 border-4 border-white bg-slate-500 rounded-full" />
+            )}
+            <label
+              htmlFor="avatarInput"
+              className="absolute flex justify-center items-center w-20 h-20 border-4 top-0 left-4 border-white rounded-full text-white cursor-pointer "
+            >
+              <div className="box rounded-full">
+                <PersonOutline fontSize="large" />
+              </div>
+            </label>
+            <button
+              className="absolute bottom-0 left-24 p-1 border border-slate-500 rounded-full text-slate-500 active:border-none active:bg-slate-500 active:text-white cursor-pointer duration-[100ms]"
+              onClick={() => {
+                setAvatarImage("");
+              }}
+              disabled={!avatarImage}
+            >
+              <CloseRounded />
+            </button>
           </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">職種</p>
-            <input
-              className="h-8 w-full p-4  bg-slate-200 rounded-md"
-              type="text"
-              ref={typeOfWork}
-            />
+          <div className="p-4">
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">ユーザー名</p>
+              <input
+                className="h-8 w-full p-4  bg-slate-200 rounded-md"
+                type="text"
+                value={username.input}
+                onChange={async (
+                  event: React.ChangeEvent<HTMLInputElement>
+                ) => {
+                  setUsername(await checkUsername(event.target.value));
+                }}
+              />
+              <p className="text-sm text-red-500">
+                {username.uniqueCheck === false &&
+                  "既に使用されているユーザー名です。"}
+              </p>
+              <p className="text-sm text-red-500">
+                {username.patternCheck === false &&
+                  "入力できない文字が含まれいます。"}
+              </p>
+            </div>
+            <div className="mb-4">
+              <label htmlFor="displayName" className="text-sm text-slate-500">
+                企業名
+              </label>
+              <input
+                id="displayName"
+                className="h-8 w-full p-4 bg-slate-200 rounded-md"
+                type="text"
+                value={displayName}
+                onChange={async (
+                  event: React.ChangeEvent<HTMLInputElement>
+                ) => {
+                  setDisplayName(event.target.value);
+                }}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">紹介文</p>
+              <textarea
+                className="w-full h-32 p-2 border-none bg-slate-200 rounded-md resize-none"
+                ref={introduction}
+                defaultValue={loginUser.introduction}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">事業主</p>
+              <input
+                className="h-8 w-full p-4  bg-slate-200 rounded-md"
+                type="text"
+                ref={owner}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">職種</p>
+              <input
+                className="h-8 w-full p-4  bg-slate-200 rounded-md"
+                type="text"
+                ref={typeOfWork}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-sm text-slate-500">住所</p>
+              <input
+                className="h-8 w-full p-4  bg-slate-200 rounded-md"
+                type="text"
+                ref={address}
+              />
+            </div>
           </div>
-          <div className="mb-4">
-            <p className="text-sm text-slate-500">住所</p>
-            <input
-              className="h-8 w-full p-4  bg-slate-200 rounded-md"
-              type="text"
-              ref={address}
-            />
+          <div className="mb-8">
+            <button
+              className="block w-24 h-8 m-auto border rounded-full font-bold border-emerald-500 text-emerald-500 hover:border-none hover:bg-emerald-500 hover:text-white
+              active:bg-emerald-500 active:text-white
+              disabled:border-slate-400 disabled:text-slate-400 disabled:bg-slate-300 cursor-pointer duration-[200ms]"
+              onClick={() => {
+                handleSubmit();
+              }}
+              disabled={
+                !username.patternCheck ||
+                !username.uniqueCheck ||
+                username.input === ""
+              }
+            >
+              登録する
+            </button>
           </div>
-        </div>
-        <div className="mb-8">
-          <button
-            className="block w-24 h-8 m-auto border rounded-full font-bold border-emerald-500 text-emerald-500 hover:border-none hover:bg-emerald-500 hover:text-slate-100 disabled:border-slate-400 disabled:text-slate-400 disabled:bg-slate-300"
-            onClick={(
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-            ) => {
-              event.preventDefault();
-              handleSubmit();
-            }}
-            disabled={
-              !username.patternCheck ||
-              !username.uniqueCheck ||
-              username.input === ""
-            }
-          >
-            登録する
-          </button>
         </div>
       </div>
     </div>

--- a/src/routes/SettingBusiness.tsx
+++ b/src/routes/SettingBusiness.tsx
@@ -202,11 +202,9 @@ const SettingBusiness = () => {
         });
       })
       .then(() => {
-        // getDoc(optionRef).then((userSnap: DocumentSnapshot<DocumentData>) => {
         setTimeout(() => {
           navigate(`/@${username.input}`);
         }, 300);
-        // });
       });
   };
   useEffect(() => {

--- a/src/routes/SignUp.tsx
+++ b/src/routes/SignUp.tsx
@@ -128,6 +128,7 @@ const SignUp: React.VFC = () => {
           skill2: "",
           skill3: "",
           typeOfWork: "",
+          uid:user.uid,
           userType: null,
           username: `@${username.input}`,
         });
@@ -140,7 +141,7 @@ const SignUp: React.VFC = () => {
           })
         );
         dispatch(toggleIsNewUser(true));
-        navigate("/", { replace: true });
+        navigate("/home", { replace: true });
       })
       .catch((error: any) => {
         if (error.message === "Firebase: Error (auth/email-already-in-use).") {

--- a/src/routes/Upload.tsx
+++ b/src/routes/Upload.tsx
@@ -73,7 +73,7 @@ const Upload: React.FC = memo(() => {
 
   return (
     <div className="md:flex md:justify-center w-screen h-screen bg-slate-400">
-      <div className="relative sm:w-screen md:w-1/2 lg:w-1/3 h-full bg-white">
+      <div className="relative w-screen md:w-1/2 lg:w-1/3 h-full bg-white">
         {loginUser.uid === "" && <Navigate to="/login" replace={true} />}
         <div className="flex relative w-full h-12 justify-center items-center bg-white z-50">
           <button


### PR DESCRIPTION
## Issue
#328 

## 変更した内容
**src/components/TabBar.tsx**
- [x] アバター画像が未登録のとき、タブバーの「自分」ボタンにnoAvatar.pngの画像が表示されるようにしました

**src/routes/Profile.tsx**
- [x] アバター画像が未登録のとき、アバター表示欄にMaterial Iconsの`<PersonOutline />`が表示されるようにしました

**src/routes/SettingAdvertise.tsx**
- [x] マウントされているときのみステートの更新とuseRefの更新をおこなうようにしました
- [x] レスポンシブ対応できるようスタイリングしました

**src/routes/SettingBusiness.tsx**
- [x] `getUser()`と`handleSubmit()`の実行条件に`isMounted === true` を追加しました
- [x] 編集画面でuidを編集することはできないので、`updateDoc()`の処理対象からuidを削除しました
- [x] handleSubmit()の処理の末尾に`getDoc(optionRef)`から始まる処理が書かれていたのですが、よく考えたらoptionRefを参照する必要がなかったため、該当箇所を削除しました
- [x] レスポンシブ対応できるよう、スタイリングを修正しました

**src/routes/SettingNormal.tsx**
- [x] 一般ユーザーはそもそも投稿機能を利用することができないので、postsコレクションを参照する`postsQuery`を削除しました
- [x] `getUser()`と`getDates()`、`handleSubmit()`の処理条件に`isMounted === true`を追加しました
- [x] `updateDoc()`の処理対象からuidを除外しました
- [x] レスポンシブ対応できるよう、スタイリングを修正しました

**src/routes/SignUp.tsx**
- [x] ユーザーの新規登録時にusersコレクションにドキュメントが新しく作成されることになっているのですが、uidフィールドが登録されない状況になっていたため、登録されるよう修正しました
- [x] 登録完了時にユーザータイプ選択画面に移動できるよう、`navigate("/", { replace: true });`を`navigate("/home", { replace: true })`に変更しました

## 動作の確認
一般ユーザーでプロフィール編集をおこなう際、エラーが発生しないことを確認します
1. ユーザーの新規登録を行います
<img width="1440" alt="スクリーンショット 2022-11-05 11 09 05" src="https://user-images.githubusercontent.com/98272835/200096897-5381e4b1-2dd5-45ae-a494-44589859f3d5.png">

2. 「一般ユーザー」を選択し、登録します
<img width="1440" alt="スクリーンショット 2022-11-05 11 09 27" src="https://user-images.githubusercontent.com/98272835/200096904-832af2a8-5610-4091-969b-2397de56b5d6.png">

3. 「自分」ボタンをクリックし、自身のプロフィールページからプロフィール編集画面へと遷移します
<img width="1440" alt="スクリーンショット 2022-11-05 11 10 57" src="https://user-images.githubusercontent.com/98272835/200096917-c2533b1a-b2a8-40bf-acf9-94d703b4d79c.png">

4.プロフィール情報を入力し、登録します
<img width="1440" alt="スクリーンショット 2022-11-05 11 18 44" src="https://user-images.githubusercontent.com/98272835/200096929-8f40c74d-cdb8-4e3d-b356-2b19f8f34a2c.png">

5. コンソールにエラーが表示されることなく、登録が完了することを確認しました
<img width="1440" alt="スクリーンショット 2022-11-05 11 19 42" src="https://user-images.githubusercontent.com/98272835/200096935-2e4a947c-f381-4c30-a1b1-972d99294468.png">

企業ユーザーでも同様の処理をおこない、エラーが発生しないことを確認しました


## 追記事項
本イシューで解決したエラーはセキュリティルールに関係するものでした。
セキュリティルールでは、ドキュメントに登録されているuidとログインしているユーザーのuidが一致した場合のみ、ドキュメントの編集権限を与えるよう、設定されていました。
しかし、ユーザーの新規登録を行う際、Firestoreに保存されるドキュメント内のフィールドに、肝心のuid情報が含まれない状態で登録されるようになっていたため、ログインしているユーザーのuidと一致する情報が、ドキュメントから取得できなくなり、エラーを起こすようになっていました