### PR TITLE
🐛 ユーザープロフィール表示画面の更新問題を解決しました

### DIFF
--- a/src/components/SelectUserType.tsx
+++ b/src/components/SelectUserType.tsx
@@ -5,7 +5,6 @@ import { selectUser, logout, updateUserType } from "../features/userSlice";
 import { auth, db } from "../firebase";
 import { signOut } from "firebase/auth";
 import { doc, updateDoc } from "firebase/firestore";
-import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewRounded";
 
 const SelectUserType = () => {
   const [userType, setUserType] = useState<"business" | "normal">("business");

--- a/src/hooks/useAdvertise.ts
+++ b/src/hooks/useAdvertise.ts
@@ -64,7 +64,7 @@ export const useAdvertise: (username: string) => AdvertiseData = (username) => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
       isMounted = false;
     };
-  }, []);
+  }, [username]);
 
   return advertise;
 };

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -43,7 +43,7 @@ export const useProfile: (username: string) => {
   followersCount: number;
   isFollowing: boolean;
   loginUser: LoginUser;
-} = (username: string) => {
+} = (username) => {
   const [user, setUser] = useState<User>({
     avatarURL: "",
     backgroundURL: "",
@@ -122,21 +122,29 @@ export const useProfile: (username: string) => {
       `users/${userSnap.docs[0].id}/followers`
     );
     onSnapshot(followingsRef, (followingsSnap: QuerySnapshot<DocumentData>) => {
-      if (isMounted === true) {
-        setFollowingsCount(followingsSnap.size);
+      if (isMounted === false) {
+        if (process.env.NODE_ENV === "development") {
+          console.log("onSnapshotをリセットしました");
+        }
+        return;
       }
+      setFollowingsCount(followingsSnap.size);
     });
     onSnapshot(followersRef, (followersSnap: QuerySnapshot<DocumentData>) => {
-      if (isMounted === true) {
-        setFollowersCount(followersSnap.size);
-        setIsFollowing(
-          followersSnap.docs.find(
-            (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
-              return followerSnap.id === loginUser.uid;
-            }
-          ) !== undefined
-        );
+      if (isMounted === false) {
+        if (process.env.NODE_ENV === "development") {
+          console.log("onSnapshotをリセットしました");
+        }
+        return;
       }
+      setFollowersCount(followersSnap.size);
+      setIsFollowing(
+        followersSnap.docs.find(
+          (followerSnap: QueryDocumentSnapshot<DocumentData>) => {
+            return followerSnap.id === loginUser.uid;
+          }
+        ) !== undefined
+      );
     });
   };
 

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -9,16 +9,18 @@ import {
 } from "react-router-dom";
 import { useProfile } from "../hooks/useProfile";
 import { usePosts } from "../hooks/usePosts";
+import { useAdvertise } from "../hooks/useAdvertise";
 import PostComponent from "../components/PostComponent";
 import TabBar from "../components/TabBar";
 import { addFollower } from "../functions/AddFollower";
 import { AdvertiseData } from "../interfaces/AdvertiseData";
-import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewRounded";
-import MailOutlined from "@mui/icons-material/MailOutlined";
-import PhotoLibraryOutlined from "@mui/icons-material/PhotoLibraryOutlined";
-import PersonAddOutlined from "@mui/icons-material/PersonAddOutlined";
-import PersonOutline from "@mui/icons-material/PersonOutline";
-import { useAdvertise } from "../hooks/useAdvertise";
+import {
+  ArrowBackIosNewRounded,
+  MailOutlined,
+  PhotoLibraryOutlined,
+  PersonAddOutlined,
+  PersonOutline,
+} from "@mui/icons-material";
 
 interface Post {
   avatarURL: string;
@@ -56,11 +58,11 @@ const Profile: React.VFC = memo(() => {
     loginUser,
   } = useProfile(username)!;
   const advertise: AdvertiseData = useAdvertise(username)!;
+  const posts: Post[] = usePosts(username)!;
   const openingHour: string = `0${advertise.openingHour}`;
   const openingMinutes: string = `0${advertise.openingMinutes}`;
   const closingHour: string = `0${advertise.closingHour}`;
   const closingMinutes: string = `0${advertise.closingMinutes}`;
-  const posts: Post[] = usePosts(username);
   let isMounted: boolean = true;
 
   useEffect(() => {
@@ -100,7 +102,7 @@ const Profile: React.VFC = memo(() => {
               navigate("/home");
             }}
           >
-            <ArrowBackRounded fontSize="small" />
+            <ArrowBackIosNewRounded fontSize="small" />
           </button>
         </div>
         <div className="flex flex-col w-screen md:w-1/2 lg:w-1/3 min-h-screen h-full bg-white">

--- a/src/routes/SettingAdvertise.tsx
+++ b/src/routes/SettingAdvertise.tsx
@@ -127,9 +127,6 @@ const SettingAdvertise = () => {
     });
   };
   useEffect(() => {
-    if (isMounted === false) {
-      return;
-    }
     getAdvertise();
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Issue
#351 

## 変更した内容
**src/hooks/useAdvertise.ts**
- [x] 引数`username`の変更をトリガーにuseEffectが実行されるよう変更しました

**src/hooks/usePosts.ts**
- [x] 引数`username`の変更をトリガーにuseEffectが実行されるよう変更しました
```
    setPosts(
          unChangedPosts.concat(changedPosts).filter((post) => {
            return post.username === username;
          })
        );
```
- [x] 引数`username`と`post.username`が一致しない`post`は除去されるようにしました

## 動作の確認

1. 検索画面に移動し、キーワードを入力し、検索

<img width="1440" alt="スクリーンショット 2022-11-27 9 03 38" src="https://user-images.githubusercontent.com/98272835/204113469-e3152710-7827-4a65-989f-6a615b42e6a4.png">

2. 検索結果に表示されたユーザー名をクリックし、他ユーザーのプロフィール表示画面に遷移

<img width="1440" alt="スクリーンショット 2022-11-27 9 03 50" src="https://user-images.githubusercontent.com/98272835/204113488-de85dc5d-d164-4ab5-bc84-abbb509a4490.png">

3. タブバーの「自分」ボタンをクリックし、ユーザー自身のプロフィール表示画面に遷移

<img width="1440" alt="スクリーンショット 2022-11-27 9 04 01" src="https://user-images.githubusercontent.com/98272835/204113536-fd0b6103-8acf-480d-8dff-c57ed2073427.png">

- [x] 他ユーザーのプロフィール表示画面が更新され、ユーザー自身の過去の投稿が表示されることを確認 

<img width="1440" alt="スクリーンショット 2022-11-27 9 04 09" src="https://user-images.githubusercontent.com/98272835/204113540-81a89a4e-dcfc-4fae-b367-b0c8bb02096a.png">

- [x] ユーザー自身の募集広告が表示されることを確認
