### PR TITLE
🐛  一般ユーザーのプロフィール編集画面に関するバグを解決しました

### DIFF
--- a/src/features/userSlice.ts
+++ b/src/features/userSlice.ts
@@ -15,11 +15,12 @@ export interface UserProfile {
   avatarURL: string;
   backgroundURL: string;
   displayName: string;
+  introduction: string;
   username: string;
 }
 export interface UserLogin {
   avatarURL: string;
-  backgroundURL:string;
+  backgroundURL: string;
   displayName: string;
   introduction: string;
   uid: string;
@@ -31,7 +32,7 @@ const initialState: LoginUser = {
   avatarURL: "",
   backgroundURL: "",
   displayName: "",
-  introduction:"",
+  introduction: "",
   isNewUser: false,
   uid: "",
   userType: null,
@@ -55,7 +56,7 @@ export const userSlice = createSlice({
       state.avatarURL = "";
       state.backgroundURL = "";
       state.displayName = "";
-      state.introduction ="";
+      state.introduction = "";
       state.uid = "";
       state.username = "";
       state.userType = null;
@@ -64,6 +65,7 @@ export const userSlice = createSlice({
       state.avatarURL = action.payload.avatarURL;
       state.backgroundURL = action.payload.backgroundURL;
       state.displayName = action.payload.displayName;
+      state.introduction = action.payload.introduction;
       state.username = action.payload.username;
     },
     updateUserType: (

--- a/src/routes/SettingBusiness.tsx
+++ b/src/routes/SettingBusiness.tsx
@@ -167,6 +167,7 @@ const SettingBusiness = () => {
         avatarURL: avatarURL,
         backgroundURL: backgroundURL,
         displayName: displayName,
+        introduction: introduction.current!.value,
         username: `@${username.input}`,
       })
     );

--- a/src/routes/SettingNormal.tsx
+++ b/src/routes/SettingNormal.tsx
@@ -22,10 +22,12 @@ import {
 import { resizeImage } from "../functions/ResizeImage";
 import { checkUsername } from "../functions/CheckUsername";
 import { checkIsUnique } from "../functions/useCheckIsUnique";
-import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewRounded";
-import PhotoLibraryOutlined from "@mui/icons-material/PhotoLibraryOutlined";
-import PersonOutline from "@mui/icons-material/PersonOutline";
-import CloseRounded from "@mui/icons-material/CloseRounded";
+import {
+  ArrowBackIosNewRounded,
+  PhotoLibraryOutlined,
+  PersonOutline,
+  CloseRounded,
+} from "@mui/icons-material";
 
 const SettingNormal = () => {
   const [isFetched, setIsFetched] = useState<boolean>(false);
@@ -51,35 +53,29 @@ const SettingNormal = () => {
   const skill1 = useRef<HTMLInputElement>(null);
   const skill2 = useRef<HTMLInputElement>(null);
   const skill3 = useRef<HTMLInputElement>(null);
-
   const navigate: NavigateFunction = useNavigate();
   const loginUser: LoginUser = useAppSelector(selectUser);
   const dispatch = useAppDispatch();
   let isMounted: boolean = true;
-
   let years: number[] = [];
   const thisYear: number = new Date().getFullYear();
   for (let i = thisYear; i >= thisYear - 100; i--) {
     years.push(i);
   }
   const months: number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-
   const loginUserRef: DocumentReference<DocumentData> = doc(
     db,
     "users",
     `${loginUser.uid}`
   );
-
   const usernameRef: DocumentReference<DocumentData> = doc(
     db,
     `usernames/${loginUser.uid}`
   );
-
   const optionRef: DocumentReference<DocumentData> = doc(
     db,
     `option/${loginUser.uid}`
   );
-
   const avatarRef: StorageReference = ref(storage, `avatars/${loginUser.uid}`);
   const backgroundRef: StorageReference = ref(
     storage,
@@ -217,6 +213,7 @@ const SettingNormal = () => {
         avatarURL: avatarURL,
         backgroundURL: backgroundURL,
         displayName: displayName,
+        introduction: introduction.current!.value,
         username: `@${username.input}`,
       })
     );
@@ -266,7 +263,7 @@ const SettingNormal = () => {
               navigate(-1);
             }}
           >
-            <ArrowBackRounded />
+            <ArrowBackIosNewRounded />
           </button>
           <p className="w-40 mx-auto font-bold">プロフィールの編集</p>
         </div>

--- a/src/routes/SignUp.tsx
+++ b/src/routes/SignUp.tsx
@@ -137,6 +137,7 @@ const SignUp: React.VFC = () => {
             avatarURL: url,
             backgroundURL: "",
             displayName: displayName,
+            introduction: "",
             username: `@${username.input}`,
           })
         );


### PR DESCRIPTION
## Issue
#354 

## 変更した内容

今回のバグは、プロフィール編集画面の修正内容をReduxに反映させる手順において、紹介文(introduction)の入力値が登録されていないことが原因でした。
そのため、`src/features/userSlice.ts`と`src/routes/SettingNormal.tsx`を修正しました。
また、`src/features/userSlice.ts`の修正に伴って、引用先の`src/routes/SettingBusiness.tsx`と`src/routes/SignUp.tsx`も同様に修正しました。


**src/features/userSlice.ts**
- [x] インターフェースUserProfileに`introduction`のプロパティを追加
- [x] setUserProfileの対象値に`state.introduction`を追加


**src/routes/SettingBusiness.tsx**
- [x] setUserProfileの対象値に`introduction.current!.value`を追加


**src/routes/SettingNormal.tsx**
- [x] setUserProfileの対象値に`introduction.current!.value`を追加


**src/routes/SignUp.tsx**
- [x] setUserProfileの対象値に`introduction:"",`を追加


## 動作の確認
1. 一般ユーザー名でログイン

2. ユーザー自身のプロフィール表示画面に遷移し、「編集する」ボタンをクリック

3. プロフィール編集画面で内容を編集し、「登録する」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-11-27 23 58 05" src="https://user-images.githubusercontent.com/98272835/204143177-cfc42583-a8bb-4152-8fba-8832d3b4cea7.png">

4. プロフィール表示画面に戻るので、再度「編集する」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-11-27 23 57 57" src="https://user-images.githubusercontent.com/98272835/204143193-c93b670e-71ab-47a2-baa6-5d8160a466c5.png">


5. 3で編集した内容が反映されて表示されていることを確認
<img width="1440" alt="スクリーンショット 2022-11-27 23 57 47" src="https://user-images.githubusercontent.com/98272835/204143220-99a78597-c7d2-476b-99b0-25b3d8692a6b.png">
