### PR TITLE
🎨 コメント一覧表示画面のレイアウトを修正しました

### DIFF
--- a/src/routes/Comments.tsx
+++ b/src/routes/Comments.tsx
@@ -71,7 +71,7 @@ const Comments: React.VFC = () => {
         </button>
         <p className="w-16 font-bold">コメント</p>
       </div>
-      <div className="flex flex-col w-screen md:w-1/2 lg:w-1/3 h-max min-h-screen mt-12 bg-white">
+      <div className="flex flex-col w-screen md:w-1/2 lg:w-1/3 h-max min-h-screen mt-12 mb-40 bg-white">
         {comments.map((comment: Comment) => {
           return (
             <div className="p-4 mb-4" key={comment.id}>


### PR DESCRIPTION
## Issue
#356 

## 変更した内容
src/routes/Comments.tsx
- [x] コメント一覧を表示する<div>タグにTailwind CSSの`mb-40` の属性を追加しました

## 動作の確認
<img width="1440" alt="スクリーンショット 2022-11-28 1 04 04" src="https://user-images.githubusercontent.com/98272835/204144989-f20dd1d1-2543-4404-b280-18a5daedbfc4.png">
画像のとおり、コメントの表示が途切れることがなくなりました