### PR TITLE
🎨 広告編集画面のレイアウトの修正、および給与の金額を桁区切りで表示するようにしました

### DIFF
--- a/src/hooks/useAdvertise.ts
+++ b/src/hooks/useAdvertise.ts
@@ -20,7 +20,7 @@ export const useAdvertise: (username: string) => AdvertiseData = (username) => {
     imageURL: "",
     jobDescription: "",
     location: "",
-    maximumWage: 0,
+    maximumWage: "",
     message: "",
     minimumWage: "",
     openingHour: 0,

--- a/src/interfaces/AdvertiseData.ts
+++ b/src/interfaces/AdvertiseData.ts
@@ -5,7 +5,7 @@ export interface AdvertiseData {
   imageURL: string;
   jobDescription: string;
   location: string;
-  maximumWage: number;
+  maximumWage: string;
   message: string;
   minimumWage: string;
   openingHour: number;

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -383,8 +383,8 @@ const Profile: React.VFC = memo(() => {
                       <p className="text-sm text-slate-500">給与</p>
                       <p className="ml-2">
                         <label className="text-sm mr-2">月額</label>
-                        {advertise!.minimumWage.toLocaleString()}円 ~{" "}
-                        {advertise!.maximumWage.toLocaleString()}円
+                        {Number(advertise!.minimumWage).toLocaleString()}円 ~{" "}
+                        {Number(advertise!.maximumWage).toLocaleString()}円
                       </p>
                     </div>
                     <div className="mb-4">

--- a/src/routes/SettingAdvertise.tsx
+++ b/src/routes/SettingAdvertise.tsx
@@ -235,16 +235,16 @@ const SettingAdvertise = () => {
             <div className="mb-4">
               <p className="text-sm text-slate-500">給与</p>
               <input
-                type="number"
+                type="string"
                 ref={minimumWage}
-                className="w-20 h-8 p-2 bg-slate-200 rounded-md"
+                className="w-24 h-8 p-2 bg-slate-200 rounded-md"
               />
               <label className="ml-2">円</label>
               <label className="mx-2">〜</label>
               <input
-                type="number"
+                type="string"
                 ref={maximumWage}
-                className="w-20 h-8 p-2 bg-slate-200 rounded-md"
+                className="w-24 h-8 p-2 bg-slate-200 rounded-md"
               />
               <label className="ml-2">円</label>
             </div>


### PR DESCRIPTION
## Issue
#358 

## 変更した内容
**src/interfaces/AdvertiseData.ts**
- [x] 金額入力時に増減ボタンを表示したくないので、maximumWageはnumber型ではなく、string型で入力するようにしました

**src/routes/Profile.tsx**
- [x] 給与金額を桁区切りを入れて表示するため、以下のコードに変更しました
``` typescript
{Number(advertise!.minimumWage).toLocaleString()}円 ~{" "}
{Number(advertise!.maximumWage).toLocaleString()}円
```

## 動作の確認
以下の画像のとおり、広告編集画面では給与金額の入力フォームの幅を広げ、広告表示画面では給与金額が桁区切りで表示されるようにしました。
<img width="1440" alt="スクリーンショット 2022-12-01 1 41 46" src="https://user-images.githubusercontent.com/98272835/204857138-9fbc927c-4fa2-441b-a76a-ed85a5c3ed91.png">

<img width="1440" alt="スクリーンショット 2022-12-01 1 40 19" src="https://user-images.githubusercontent.com/98272835/204857200-49865e95-638f-4278-af75-c9ae5d791cfb.png">

