### PR TITLE
🐛 optionコレクションのエラー問題を解決しました

### DIFF
--- a/src/routes/SettingBusiness.tsx
+++ b/src/routes/SettingBusiness.tsx
@@ -26,10 +26,12 @@ import {
 } from "firebase/storage";
 import { resizeImage } from "../functions/ResizeImage";
 import { checkUsername } from "../functions/CheckUsername";
-import ArrowBackRounded from "@mui/icons-material/ArrowBackIosNewRounded";
-import PhotoLibraryOutlined from "@mui/icons-material/PhotoLibraryOutlined";
-import PersonOutline from "@mui/icons-material/PersonOutline";
-import CloseRounded from "@mui/icons-material/CloseRounded";
+import {
+  ArrowBackIosNewRounded,
+  PhotoLibraryOutlined,
+  PersonOutline,
+  CloseRounded,
+} from "@mui/icons-material";
 
 const SettingBusiness = () => {
   const [isFetched, setIsFetched] = useState<boolean>(false);
@@ -95,12 +97,15 @@ const SettingBusiness = () => {
       input: loginUser.username.slice(1),
     });
     introduction.current!.value = loginUser.introduction;
-    getDoc(optionRef).then((optionSnap: DocumentSnapshot<DocumentData>) => {
-      address.current!.value = optionSnap.data()!.address;
-      owner.current!.value = optionSnap.data()!.owner;
-      typeOfWork.current!.value = optionSnap.data()!.typeOfWork;
-      setIsFetched(true);
-    });
+    getDoc(optionRef)
+      .then((optionSnap: DocumentSnapshot<DocumentData>) => {
+        owner.current!.value = optionSnap.data()!.owner;
+        typeOfWork.current!.value = optionSnap.data()!.typeOfWork;
+        address.current!.value = optionSnap.data()!.address;
+      })
+      .then(() => {
+        setIsFetched(true);
+      });
   };
 
   const onChangeImageHandler: (
@@ -190,7 +195,7 @@ const SettingBusiness = () => {
     updateProfile(auth.currentUser!, {
       displayName: displayName,
       photoURL: avatarURL,
-    });
+    })
     getDocs(postsQuery)
       .then((posts: QuerySnapshot<DocumentData>) => {
         posts.forEach((post) => {
@@ -229,7 +234,7 @@ const SettingBusiness = () => {
               navigate(-1);
             }}
           >
-            <ArrowBackRounded />
+            <ArrowBackIosNewRounded />
           </button>
           <p className="w-40 mx-auto font-bold">プロフィールの編集</p>
         </div>


### PR DESCRIPTION
## 🔎分析結果
「事業主」「職種」「住所」のデータはFIrestoreのoptionコレクションのドキュメントのフィールドに格納されているため、これらの値が登録されないのは、optionコレクションのセキュリティルールに関係してくると予想。
optionコレクションのセキュリティルールは以下のとおりとなっており、ルールの記述自体におかしなところはありませんでした。

```
// optionコレクション
    match /option/{userId}{
    	allow read: if request.auth != null;
      allow update, delete: if request.auth != null
      	&& request.auth.uid == request.resource.data.uid;
      allow create: if request.auth != null;
    }
```

つぎにFiresotoreのoptionコレクションを参照したところ、以下のとおり、エラーが起きているユーザーのドキュメントには「uid」フィールドが登録されていない事実が判明しました。

<img width="1440" alt="スクリーンショット 2022-12-01 18 23 48" src="https://user-images.githubusercontent.com/98272835/205017308-88fdf957-59d4-4428-b124-9d0e30471af5.png">

<img width="1440" alt="スクリーンショット 2022-12-01 18 24 02" src="https://user-images.githubusercontent.com/98272835/205017320-58d7c3bd-35c8-43d5-afc2-7ff1cb25bfec.png">

したがって、今回のエラーはコードの内容の不備によるものではなく、Firestoreのドキュメントの欠陥によるものだと思われます。

## 動作の確認
1. 「minami_farm」のアカウントでログイン
2. プロフィール編集画面に移動
3. 「事業主」「職種」「住所」の情報を入力し、「登録する」ボタンをクリック
<img width="1440" alt="スクリーンショット 2022-12-01 18 36 37" src="https://user-images.githubusercontent.com/98272835/205019271-e5aab8f5-1b09-422a-9fb0-c774cc046298.png">

4. プロフィール表示画面に、３の工程で登録した情報が表示されることを確認
<img width="1440" alt="スクリーンショット 2022-12-01 18 36 55" src="https://user-images.githubusercontent.com/98272835/205019419-9c4891c7-6d05-48ea-b5e7-9d0686b425c7.png">
