### PR TITLE
🎨 PostDetailの給与を桁区切りで表示できるようにしました

### DIFF
--- a/src/routes/PostDetail.tsx
+++ b/src/routes/PostDetail.tsx
@@ -168,8 +168,8 @@ const PostDetail: React.VFC = memo(() => {
                 <p className="text-sm text-slate-500">給与</p>
                 <p className="ml-2">
                   <label className="text-sm mr-2">月額</label>
-                  {advertise!.minimumWage.toLocaleString()}円 ~{" "}
-                  {advertise!.maximumWage.toLocaleString()}円
+                  {Number(advertise!.minimumWage).toLocaleString()}円 ~{" "}
+                  {Number(advertise!.maximumWage).toLocaleString()}円
                 </p>
               </div>
               <div className="mb-4">


### PR DESCRIPTION
## Issue
#365 

## 変更した内容
**src/routes/PostDetail.tsx**
`advertise!.maximumWage`と`advertise!.minimumWage`をnumber型に変更する処理を追加しました

## 動作の確認
<img width="1440" alt="スクリーンショット 2022-12-02 22 00 17" src="https://user-images.githubusercontent.com/98272835/205298700-0f062240-d350-41b4-95bc-97c239d74f7f.png">

「給与」が桁区切りになっていることを確認しました
