### PR TITLE
🐛 ログアウト時のuncaught errorを解決しました

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { useAppDispatch, useAppSelector } from "./app/hooks";
 import { Navigate, Outlet, Route, Routes } from "react-router-dom";
 import { selectUser, login, logout, LoginUser } from "./features/userSlice";
 import { auth, db } from "./firebase";
-import { onAuthStateChanged, Unsubscribe, User } from "firebase/auth";
+import { onAuthStateChanged, Unsubscribe, User, signOut } from "firebase/auth";
 import {
   doc,
   DocumentData,
@@ -55,8 +55,11 @@ const App: React.FC = () => {
     );
     return () => {
       unsubscribe();
+      if (loginUser.uid === "") {
+        signOut(auth);
+      }
     };
-  }, [dispatch]);
+  }, [dispatch, loginUser.uid]);
 
   if (loginUser.uid !== "") {
     return (


### PR DESCRIPTION
## Issue
#376 

## 変更した内容
**src/App.tsx**
- [x] useEffectのクリーンアップ関数の中に以下のコードを追加
``` typescript
    if (loginUser.uid === "") {
        signOut(auth);
      }
```

- [x] useEffectのトリガーとして`loginUser.uid`を追加

## 動作の確認
1. アプリにログイン
2. ログアウトボタンをクリック
<img width="1440" alt="スクリーンショット 2022-12-17 6 31 51" src="https://user-images.githubusercontent.com/98272835/208195073-54fdf29c-8cce-49d3-9731-a20f288f47d2.png">

3. ログイン画面に遷移。開発者ツールのコンソールにエラーが表示されていないことを確認
<img width="1440" alt="スクリーンショット 2022-12-17 6 32 01" src="https://user-images.githubusercontent.com/98272835/208195111-33bb9c14-e434-4f36-9ac0-33e7bf29c823.png">


4. URLを http://localhost:3000/login から http://localhost:3000/home に変更
<img width="1440" alt="スクリーンショット 2022-12-17 6 32 14" src="https://user-images.githubusercontent.com/98272835/208195156-4a7eb7df-267e-4e21-a306-07a1d1aeade0.png">

5. http://localhost:3000/home に遷移すると画面読み込みに失敗するので、ログアウト処理が正常に行われていることを確認
<img width="1440" alt="スクリーンショット 2022-12-17 6 32 28" src="https://user-images.githubusercontent.com/98272835/208195167-cb7192b3-dc2c-4d0e-88b5-2f866a5d1f1f.png">